### PR TITLE
publicize GetDllPath + option to use latest DLL + exec and eval accept utf8 code

### DIFF
--- a/PythonForDelphi/Components/Sources/Core/PythonEngine.pas
+++ b/PythonForDelphi/Components/Sources/Core/PythonEngine.pas
@@ -1518,6 +1518,7 @@ type
     procedure BeforeUnload; virtual;
     function  GetQuitMessage : String; virtual;
     procedure DoOpenDll(const aDllName : String); virtual;
+    function  GetDllPath : String;
 
   public
     // Constructors & Destructors
@@ -1530,7 +1531,6 @@ type
     procedure LoadDll;
     procedure UnloadDll;
     procedure Quit;
-    function  GetDllPath : String;
 
     // Public properties
   published
@@ -2207,7 +2207,6 @@ type
     FPyDateTime_TZInfoType:      PPyObject;
     FPyDateTime_TimeTZType:      PPyObject;
     FPyDateTime_DateTimeTZType:  PPyObject;
-    FUseLatestDll:               boolean;
     function  GetVersion: String;
     procedure SetVersion(const Value: String);
 
@@ -4601,7 +4600,6 @@ begin
   FUseWindowsConsole       := False;
   FPyFlags                 := [];
   FDatetimeConversionMode  := DEFAULT_DATETIME_CONVERSION_MODE;
-  FUseLatestDll            := True;
   if csDesigning in ComponentState then
     begin
       for i := 0 to AOwner.ComponentCount - 1 do
@@ -4718,18 +4716,10 @@ end;
 
 procedure TPythonEngine.DoOpenDll(const aDllName : String);
 var
-  i, stop : Integer;
+  i : Integer;
 begin
-  if UseLastKnownVersion then begin
-    if FUseLatestDll then begin
-      i := High(PYTHON_KNOWN_VERSIONS);
-      stop := Integer(COMPILED_FOR_PYTHON_VERSION_INDEX)-1
-    end
-    else begin
-      i := Integer(COMPILED_FOR_PYTHON_VERSION_INDEX);
-      stop := High(PYTHON_KNOWN_VERSIONS)+1
-    end;
-    while i <> stop do
+  if UseLastKnownVersion then
+    for i:= Integer(COMPILED_FOR_PYTHON_VERSION_INDEX) to High(PYTHON_KNOWN_VERSIONS) do
     begin
       RegVersion := PYTHON_KNOWN_VERSIONS[i].RegVersion;
       FDLLHandle := SafeLoadLibrary(GetDllPath+PYTHON_KNOWN_VERSIONS[i].DllName);
@@ -4741,12 +4731,7 @@ begin
       end;
       if not PYTHON_KNOWN_VERSIONS[i].CanUseLatest then
         Break;
-      if FUseLatestDll then
-        i:=i-1
-      else
-        i:=i+1;
     end;
-  end;
   inherited;
 end;
 


### PR DESCRIPTION
3 changes:
* GetDllPath moved to public: useful for people who want to make sure they're using the right python environment
* Option to use latest DLL: needed for machines with both 2.7 and 3.x that want to use 3.x. changes the version search to be reversed (last version is tested first)
* utf8: The cleaned strings are now convererted to utf8, allowing for strings in other languges in 3.x