### PR TITLE
SetPythonHome; Ansi/UTF8 eval; warning sielnt

### DIFF
--- a/PythonForDelphi/Components/Sources/Core/PythonEngine.pas
+++ b/PythonForDelphi/Components/Sources/Core/PythonEngine.pas
@@ -5307,12 +5307,12 @@ end;
 
 procedure TPythonEngine.ExecStrings( strings : TStrings );
 begin
-  Py_XDecRef( Run_CommandAsObject( CleanString( AnsiString(strings.Text) ), file_input ) );
+  Py_XDecRef( Run_CommandAsObject( CleanString( UTF8Encode(strings.Text) ), file_input ) );
 end;
 
 function TPythonEngine.EvalStrings( strings : TStrings ) : PPyObject;
 begin
-  Result := Run_CommandAsObject( CleanString( AnsiString(strings.Text) ), eval_input );
+  Result := Run_CommandAsObject( CleanString( UTF8Encode(strings.Text) ), eval_input );
 end;
 
 procedure TPythonEngine.ExecString(const command : AnsiString; locals, globals : PPyObject );
@@ -5322,7 +5322,7 @@ end;
 
 procedure TPythonEngine.ExecStrings( strings : TStrings; locals, globals : PPyObject );
 begin
-  Py_XDecRef( Run_CommandAsObjectWithDict( CleanString( AnsiString(strings.Text) ), file_input, locals, globals ) );
+  Py_XDecRef( Run_CommandAsObjectWithDict( CleanString( UTF8Encode(strings.Text) ), file_input, locals, globals ) );
 end;
 
 function TPythonEngine.EvalString( const command : AnsiString; locals, globals : PPyObject ) : PPyObject;
@@ -5332,12 +5332,12 @@ end;
 
 function TPythonEngine.EvalStrings( strings : TStrings; locals, globals : PPyObject ) : PPyObject;
 begin
-  Result := Run_CommandAsObjectWithDict( CleanString( AnsiString(strings.Text) ), eval_input, locals, globals );
+  Result := Run_CommandAsObjectWithDict( CleanString( UTF8Encode(strings.Text) ), eval_input, locals, globals );
 end;
 
 function TPythonEngine.EvalStringsAsStr( strings : TStrings ) : String;
 begin
-  Result := Run_CommandAsString( CleanString( AnsiString(strings.Text) ), eval_input );
+  Result := Run_CommandAsString( CleanString( UTF8Encode(strings.Text) ), eval_input );
 end;
 
 function TPythonEngine.CheckEvalSyntax( const str : AnsiString ) : Boolean;

--- a/PythonForDelphi/Components/Sources/Core/PythonEngine.pas
+++ b/PythonForDelphi/Components/Sources/Core/PythonEngine.pas
@@ -2253,6 +2253,7 @@ type
     function   Run_CommandAsString(const command : AnsiString; mode : Integer) : String;
     function   Run_CommandAsObject(const command : AnsiString; mode : Integer) : PPyObject;
     function   Run_CommandAsObjectWithDict(const command : AnsiString; mode : Integer; locals, globals : PPyObject) : PPyObject;
+    function   ToPythonRawString (str: String): AnsiString;
     procedure  ExecString(const command : AnsiString); overload;
     procedure  ExecStrings( strings : TStrings ); overload;
     function   EvalString(const command : AnsiString) : PPyObject; overload;
@@ -5135,7 +5136,7 @@ end;
 procedure TPythonEngine.SetPythonHome(PythonHome: String);
 begin
   FPythonHomeW := PythonHome;
-  FPythonHome := UTF8Encode(PythonHome);
+  FPythonHome := ToPythonRawString(PythonHome);
 end;
 
 function TPythonEngine.IsType(ob: PPyObject; obt: PPyTypeObject): Boolean;
@@ -5307,12 +5308,12 @@ end;
 
 procedure TPythonEngine.ExecStrings( strings : TStrings );
 begin
-  Py_XDecRef( Run_CommandAsObject( CleanString( UTF8Encode(strings.Text) ), file_input ) );
+  Py_XDecRef( Run_CommandAsObject( CleanString( ToPythonRawString(strings.Text) ), file_input ) );
 end;
 
 function TPythonEngine.EvalStrings( strings : TStrings ) : PPyObject;
 begin
-  Result := Run_CommandAsObject( CleanString( UTF8Encode(strings.Text) ), eval_input );
+  Result := Run_CommandAsObject( CleanString( ToPythonRawString(strings.Text) ), eval_input );
 end;
 
 procedure TPythonEngine.ExecString(const command : AnsiString; locals, globals : PPyObject );
@@ -5322,7 +5323,7 @@ end;
 
 procedure TPythonEngine.ExecStrings( strings : TStrings; locals, globals : PPyObject );
 begin
-  Py_XDecRef( Run_CommandAsObjectWithDict( CleanString( UTF8Encode(strings.Text) ), file_input, locals, globals ) );
+  Py_XDecRef( Run_CommandAsObjectWithDict( CleanString( ToPythonRawString(strings.Text) ), file_input, locals, globals ) );
 end;
 
 function TPythonEngine.EvalString( const command : AnsiString; locals, globals : PPyObject ) : PPyObject;
@@ -5332,12 +5333,12 @@ end;
 
 function TPythonEngine.EvalStrings( strings : TStrings; locals, globals : PPyObject ) : PPyObject;
 begin
-  Result := Run_CommandAsObjectWithDict( CleanString( UTF8Encode(strings.Text) ), eval_input, locals, globals );
+  Result := Run_CommandAsObjectWithDict( CleanString( ToPythonRawString(strings.Text) ), eval_input, locals, globals );
 end;
 
 function TPythonEngine.EvalStringsAsStr( strings : TStrings ) : String;
 begin
-  Result := Run_CommandAsString( CleanString( UTF8Encode(strings.Text) ), eval_input );
+  Result := Run_CommandAsString( CleanString( ToPythonRawString(strings.Text) ), eval_input );
 end;
 
 function TPythonEngine.CheckEvalSyntax( const str : AnsiString ) : Boolean;
@@ -5683,6 +5684,14 @@ begin
           Result := Clients[i];
           Break;
         end;
+end;
+
+function TPythonEngine.ToPythonRawString(str: String): AnsiString;
+begin
+  if IsPython3000 then
+    Result := UTF8Encode(str)
+  else
+    Result := AnsiString(str);
 end;
 
 function   TPythonEngine.TypeByName( const aTypeName : AnsiString ) : PPyTypeObject;

--- a/PythonForDelphi/Components/Sources/Core/PythonEngine.pas
+++ b/PythonForDelphi/Components/Sources/Core/PythonEngine.pas
@@ -9753,12 +9753,12 @@ begin
       exOverflow, exUnderflow, exPrecision])
   else
     SetExceptionMask([exDenormalized, exUnderflow, exPrecision]);
-{$IFNDEF NEXTGEN}
+{$IFNDEF NEXTGEN}{$WARN SYMBOL_PLATFORM OFF}
   if MatchPythonPrecision then
       SetPrecisionMode(pmDouble)
     else
       SetPrecisionMode(pmExtended);
-{$ENDIF !NEXTGEN}
+{$ENDIF !NEXTGEN}{$WARN SYMBOL_PLATFORM ON}
 end;
 
 {$IFDEF MSWINDOWS}


### PR DESCRIPTION
Hi,

Please review and merge these changes:
1. SetPythonHome - required for instance for supporting OSGEO4W Python without setting environment variable externally. (setting environment variable internally from within the app doesn't work for PythonHome, thus the use of this function)
2. Ansi/UTF8 eval/execute according to Python version
3. silent a redundant warning

RE: Option to use latest DLL: needed for machines with both 2.7 and 3.x that want to use 3.x. changes the version search to be reversed (last version is tested first)
You wrote: Have a look at PythonVersions.pas. It does all that and more. 
Please advise how to make Python4delphi prefer the newer python version.

Kind Regards,
Idan
