### PR TITLE
"UseLastKnownVersion" suggests that if two versions are available in …

### DIFF
--- a/PythonForDelphi/Components/Sources/Core/PythonEngine.pas
+++ b/PythonForDelphi/Components/Sources/Core/PythonEngine.pas
@@ -4733,7 +4733,7 @@ var
   i : Integer;
 begin
   if UseLastKnownVersion then
-    for i:= Integer(COMPILED_FOR_PYTHON_VERSION_INDEX) to High(PYTHON_KNOWN_VERSIONS) do
+    for i:= High(PYTHON_KNOWN_VERSIONS) downto Integer(COMPILED_FOR_PYTHON_VERSION_INDEX) do
     begin
       RegVersion := PYTHON_KNOWN_VERSIONS[i].RegVersion;
       FDLLHandle := SafeLoadLibrary(GetDllPath+PYTHON_KNOWN_VERSIONS[i].DllName);


### PR DESCRIPTION
…the same folder then the later one will be chosen.
i.e. in case both Python27 and Python36 are available in the same folder (as in OSGeo4W, for instance).
The other option to load Python36 in that case would be to specify explicitly "DllName", which defetes the purpose of "last known version".
The "PythonVersions.GetLatestRegisteredPythonVersion(PythonVersion)" method won't help because the python version I require is not "registered" but loaded from a given path.
