### PR TITLE
VarPyth fix for named parameters in multithreaded environment issue #125

### DIFF
--- a/PythonForDelphi/Components/Sources/Core/VarPyth.pas
+++ b/PythonForDelphi/Components/Sources/Core/VarPyth.pas
@@ -1088,7 +1088,7 @@ procedure TPythonVariantType.DispInvoke(Dest: PVarData;
 Var
   NewCallDesc : TCallDesc;
 begin
-  if CallDesc^.NamedArgCount > 0 then GetNamedParams;
+  GetNamedParams;
   try
     if (CallDesc^.CallType = CPropertyGet) and (CallDesc^.ArgCount = 1) then begin
       NewCallDesc := CallDesc^;
@@ -1105,7 +1105,7 @@ begin
       inherited;
       {$ENDIF PATCHEDSYSTEMDISPINVOKE}
   finally
-    if CallDesc^.NamedArgCount > 0 then SetLength(fNamedParams, 0);
+    SetLength(fNamedParams, 0);
   end;
 end;
 


### PR DESCRIPTION
Supposed fix to Named parameters in VarPyth not cleared between function calls #125 issue. The patch is very inelegant, but I cannot see any side effects. As I understand, all data from named parameters is copied to a python object prior to do the actual function call, so truncation of fNamedParams should be OK at any moment.