### PR TITLE
array return & better overload

### DIFF
--- a/Source/WrapDelphi.pas
+++ b/Source/WrapDelphi.pas
@@ -2806,22 +2806,25 @@ function TPyDelphiMethodObject.Call(ob1, ob2: PPyObject): PPyObject;
     PyValue : PPyObject;
     Param: TRttiParameter;
     Params : TArray<TRttiParameter>;
+    SearchContinue: Boolean;
   begin
-    Result :=nil;
+    Result := nil;
     for Method in RttiType.GetMethods do
       if SameText(Method.Name, MethName) then
       begin
-        Params:=Method.GetParameters;
-        if Length(Args)=Length(Params) then
+        Params := Method.GetParameters;
+        if Length(Args) = Length(Params) then
         begin
           Result := Method;
-          for Index:= 0 to Length(Params)-1 do
+          SearchContinue := False;
+          for Index := 0 to Length(Params) - 1 do
           begin
             Param := Params[Index];
             if (Param.ParamType = nil) or
               (Param.Flags * [TParamFlag.pfVar, TParamFlag.pfOut] <> []) then
             begin
-              Result :=nil;
+              Result := nil;
+              SearchContinue := True;
               Break;
             end;
 
@@ -2860,8 +2863,10 @@ function TPyDelphiMethodObject.Call(ob1, ob2: PPyObject): PPyObject;
               Result :=nil;
               Break;
             end;
-          end;
-          Break;
+          end; // for params
+
+          if not SearchContinue then
+            Break;
         end;
      end;
   end;

--- a/Source/WrapDelphi.pas
+++ b/Source/WrapDelphi.pas
@@ -946,6 +946,19 @@ end;
 { Helper functions }
 
 {$IFDEF EXTENDED_RTTI}
+function DynArrayToPython(const Value: TValue): PPyObject;
+var
+  I: Integer;
+  V: Variant;
+begin
+  Result := GetPythonEngine().PyList_New(Value.GetArrayLength);
+  for I := 0 to Value.GetArrayLength() - 1 do
+  begin
+    V := Value.GetArrayElement(i).AsVariant;
+    GetPythonEngine().PyList_SetItem(Result, I, GetPythonEngine().VariantAsPyObject(V));
+  end;
+end;
+
 function SimpleValueToPython(const Value: TValue; out ErrMsg: string): PPyObject;
 begin
   Result := nil;
@@ -980,8 +993,10 @@ begin
           Result := SetToPython(Value.TypeData.CompType^,
             PInteger(Value.GetReferenceToRawData)^);
         end;
-      tkClass, tkMethod, tkArray,
-      tkRecord, tkInterface, tkDynArray,
+      tkArray, tkDynArray:
+        Result := DynArrayToPython(Value);
+      tkClass, tkMethod,
+      tkRecord, tkInterface,
       tkClassRef, tkPointer, tkProcedure:
         ErrMsg := rs_ErrValueToPython;
     else
@@ -1045,7 +1060,7 @@ begin
           Result := True;
         end;
       tkClass, tkMethod, tkArray,
-      tkRecord, tkInterface, tkDynArray,
+      tkRecord, tkInterface,
       tkClassRef, tkPointer, tkProcedure:
         ErrMsg := rs_ErrPythonToValue;
     else

--- a/Tests/WrapDelphiTest.pas
+++ b/Tests/WrapDelphiTest.pas
@@ -54,7 +54,8 @@ type
     function GetStaticArray: TStaticArray;
     property Fruit: TFruit read FFruit write FFruit;
     property Fruits: TFruits read FFruits write FFruits;
-
+    function SetStringField(var Value: Integer): string; overload;
+    function SetStringField(const Value: string): string; overload;
   end;
 
   TTestInterfaceImpl = class(TInterfacedObject, ITestInterface)
@@ -113,6 +114,8 @@ type
     procedure TestGetDynArray;
     [Test]
     procedure TestGetStaticArray;
+    [Test]
+    procedure TestMethodWithVarAndOverload;
   end;
 
 implementation
@@ -394,6 +397,24 @@ begin
   TestRttiAccess.Fruits := [TFruit.Apple, TFruit.Banana, TFruit.Orange];
   Rtti_Var.SellFruits(VarPythonCreate([Ord(TFruit.Apple), Ord(TFruit.Banana)], stList));
   Assert.IsTrue(TestRttiAccess.Fruits = [Orange]);
+end;
+
+procedure TTestWrapDelphi.TestMethodWithVarAndOverload;
+begin
+  Rtti_Var.SetStringField('test');
+  Assert.AreEqual('test', TestRttiAccess.StringField);
+end;
+
+function TTestRttiAccess.SetStringField(const Value: string): string;
+begin
+  StringField := Value;
+  Result := StringField;
+end;
+
+function TTestRttiAccess.SetStringField(var Value: Integer): string;
+begin
+  StringField := IntToStr(Value);
+  Result := StringField;
 end;
 
 function TTestRttiAccess.GetDynArray: TInt64DynArray;

--- a/Tests/WrapDelphiTest.pas
+++ b/Tests/WrapDelphiTest.pas
@@ -34,6 +34,7 @@ type
   end;
 
   TFruitDynArray = TArray<TFruit>;
+  TStaticArray = array[0..999] of Int64;
   TTestRttiAccess = class
   private
     FFruit: TFruit;
@@ -49,6 +50,8 @@ type
     procedure BuyFruits(AFruits: TFruits);
     procedure SellFruits(const AFruits: TFruitDynArray);
     procedure SellFruitsInt(const AFruits:TIntegerDynArray);
+    function GetDynArray: TInt64DynArray;
+    function GetStaticArray: TStaticArray;
     property Fruit: TFruit read FFruit write FFruit;
     property Fruits: TFruits read FFruits write FFruits;
 
@@ -106,6 +109,10 @@ type
     procedure TestInterfaceField;
     [Test]
     procedure TestDynArrayParameters;
+    [Test]
+    procedure TestGetDynArray;
+    [Test]
+    procedure TestGetStaticArray;
   end;
 
 implementation
@@ -215,6 +222,26 @@ begin
   Assert.IsTrue(RTTI_var.Fruit = 'Apple');
   Rtti_Var.Fruit := 'Banana';
   Assert.IsTrue(TestRttiAccess.Fruit = Banana);
+end;
+
+procedure TTestWrapDelphi.TestGetDynArray;
+var
+  List: Variant;
+begin
+  List := Rtti_Var.GetDynArray();
+  Assert.IsTrue(VarIsPythonList(List));
+  Assert.AreEqual(1000000, Integer(len(List)));
+  Assert.AreEqual(Int64(999999), Int64(PythonEngine.PyObjectAsVariant(PythonEngine.PyList_GetItem(ExtractPythonObjectFrom(List), 999999))));
+end;
+
+procedure TTestWrapDelphi.TestGetStaticArray;
+var
+  List: Variant;
+begin
+  List := Rtti_Var.GetStaticArray();
+  Assert.IsTrue(VarIsPythonList(List));
+  Assert.AreEqual(1000, Integer(len(List)));
+  Assert.AreEqual(Int64(999), Int64(PythonEngine.PyObjectAsVariant(PythonEngine.PyList_GetItem(ExtractPythonObjectFrom(List), 999))));
 end;
 
 procedure TTestWrapDelphi.TestInterface;
@@ -367,6 +394,23 @@ begin
   TestRttiAccess.Fruits := [TFruit.Apple, TFruit.Banana, TFruit.Orange];
   Rtti_Var.SellFruits(VarPythonCreate([Ord(TFruit.Apple), Ord(TFruit.Banana)], stList));
   Assert.IsTrue(TestRttiAccess.Fruits = [Orange]);
+end;
+
+function TTestRttiAccess.GetDynArray: TInt64DynArray;
+var
+  I: Integer;
+begin
+  SetLength(Result, 1000000);
+  for I := 0 to Length(Result) - 1 do
+    Result[I] := I;
+end;
+
+function TTestRttiAccess.GetStaticArray: TStaticArray;
+var
+  I: Integer;
+begin
+  for I := 0 to Length(Result) - 1 do
+    Result[I] := I;
 end;
 
 procedure TTestRttiAccess.SellFruits(const AFruits: TFruitDynArray);


### PR DESCRIPTION
hi, PR has 2 improvements:
1. returned dynamic array to python list conversion
2. more flexible searching in FindMethod - when a few methods has the same name and param count then method with unsupported var should be skiped  and find should try another with different parameters type