### PR TITLE
Styledcontrolwrapper

### DIFF
--- a/Source/fmx/WrapFmxControls.pas
+++ b/Source/fmx/WrapFmxControls.pas
@@ -376,6 +376,7 @@ procedure TControlsRegistration.RegisterWrappers(
 begin
   inherited;
   APyDelphiWrapper.RegisterDelphiWrapper(TPyDelphiControl);
+  APyDelphiWrapper.RegisterDelphiWrapper(TPyDelphiStyledControl);
 end;
 
 { TControlsAccess }

--- a/Source/fmx/WrapFmxControls.pas
+++ b/Source/fmx/WrapFmxControls.pas
@@ -82,6 +82,7 @@ type
     function Get_StyleLookup(AContext: Pointer): PPyObject; cdecl;
     function Get_AutoTranslate(AContext: Pointer): PPyObject; cdecl;
     function Get_AdjustSizeValue(AContext: Pointer): PPyObject; cdecl;
+    function Get_AdjustType(AContext: Pointer): PPyObject; cdecl;
     // Property Setters
     function Set_StyleLookup(AValue: PPyObject; AContext: Pointer): integer; cdecl;
     function Set_AutoTranslate(AValue: PPyObject; AContext: Pointer): integer; cdecl;
@@ -500,6 +501,12 @@ begin
   Result := WrapSizeF(PyDelphiWrapper, DelphiObject.AdjustSizeValue);
 end;
 
+function TPyDelphiStyledControl.Get_AdjustType(AContext: Pointer): PPyObject;
+begin
+  Adjust(@Self);
+  Result := GetPythonEngine.PyLong_FromLong(Ord(DelphiObject.AdjustType));
+end;
+
 function TPyDelphiStyledControl.Get_AutoTranslate(AContext: Pointer): PPyObject;
 begin
   Adjust(@Self);
@@ -556,6 +563,9 @@ begin
       'Specifies whether the control''s text should be translated', nil);
     AddGetSet('AdjustSizeValue', @TPyDelphiStyledControl.Get_AdjustSizeValue, nil,
       'Updates the width and height of this control according to its current style', nil);
+    AddGetSet('AdjustType', @TPyDelphiStyledControl.Get_AdjustType, nil,
+      'Determines if and how the width and height of this control should be '
+      + 'modified to take the fixed space dictated by the style of this control', nil);
   end;
 end;
 

--- a/Source/fmx/WrapFmxControls.pas
+++ b/Source/fmx/WrapFmxControls.pas
@@ -76,8 +76,10 @@ type
     // Property Getters
     function Get_DefaultStyleLookupName(AContext: Pointer): PPyObject; cdecl;
     function Get_StyleLookup(AContext: Pointer): PPyObject; cdecl;
+    function Get_AutoTranslate(AContext: Pointer): PPyObject; cdecl;
     // Property Setters
     function Set_StyleLookup(AValue: PPyObject; AContext: Pointer): integer; cdecl;
+    function Set_AutoTranslate(AValue: PPyObject; AContext: Pointer): integer; cdecl;
   public
     class function DelphiObjectClass: TClass; override;
     class procedure RegisterGetSets(PythonType: TPythonType); override;
@@ -458,6 +460,12 @@ begin
   Result := TStyledControl(inherited DelphiObject);
 end;
 
+function TPyDelphiStyledControl.Get_AutoTranslate(AContext: Pointer): PPyObject;
+begin
+  Adjust(@Self);
+  Result := GetPythonEngine.VariantAsPyObject(Self.DelphiObject.AutoTranslate);
+end;
+
 function TPyDelphiStyledControl.Get_DefaultStyleLookupName(
   AContext: Pointer): PPyObject;
 begin
@@ -476,9 +484,11 @@ begin
   inherited;
   with PythonType do begin
     AddGetSet('DefaultStyleLookupName', @TPyDelphiStyledControl.Get_StyleLookup, nil,
-      'Provides access to the default style lookup name of a StyledControl', nil);
+      'Returns a string with the name of the default style of this control', nil);
     AddGetSet('StyleLookup', @TPyDelphiStyledControl.Get_StyleLookup, @TPyDelphiStyledControl.Set_StyleLookup,
-      'Provides access to the style lookup of a StyledControl', nil);
+      'Specifies the name of the resource object to which the current TStyledControl is linked', nil);
+    AddGetSet('AutoTranslate', @TPyDelphiStyledControl.Get_AutoTranslate, @TPyDelphiStyledControl.Set_AutoTranslate,
+      'Specifies whether the control''s text should be translated', nil);
   end;
 end;
 
@@ -490,6 +500,21 @@ end;
 procedure TPyDelphiStyledControl.SetDelphiObject(const Value: TStyledControl);
 begin
   inherited DelphiObject := Value;
+end;
+
+function TPyDelphiStyledControl.Set_AutoTranslate(AValue: PPyObject;
+  AContext: Pointer): integer;
+var
+  LValue: Boolean;
+begin
+  Adjust(@Self);
+  if CheckBoolAttribute(AValue, 'AutoTranslate', LValue) then
+  begin
+    DelphiObject.AutoTranslate := LValue;
+    Result := 0;
+  end
+  else
+    Result := -1;
 end;
 
 function TPyDelphiStyledControl.Set_StyleLookup(AValue: PPyObject;

--- a/Source/fmx/WrapFmxControls.pas
+++ b/Source/fmx/WrapFmxControls.pas
@@ -465,6 +465,10 @@ end;
 class procedure TPyDelphiStyledControl.RegisterGetSets(PythonType: TPythonType);
 begin
   inherited;
+  with PythonType do begin
+    AddGetSet('StyleLookup', @TPyDelphiStyledControl.Get_StyleLookup, @TPyDelphiStyledControl.Set_StyleLookup,
+      'Provides access to the StyleLookup of a StyledControl', nil);
+  end;
 end;
 
 class procedure TPyDelphiStyledControl.RegisterMethods(PythonType: TPythonType);

--- a/Source/fmx/WrapFmxControls.pas
+++ b/Source/fmx/WrapFmxControls.pas
@@ -83,6 +83,7 @@ type
     function Get_AutoTranslate(AContext: Pointer): PPyObject; cdecl;
     function Get_AdjustSizeValue(AContext: Pointer): PPyObject; cdecl;
     function Get_AdjustType(AContext: Pointer): PPyObject; cdecl;
+    function Get_StyleState(AContext: Pointer): PPyObject; cdecl;
     // Property Setters
     function Set_StyleLookup(AValue: PPyObject; AContext: Pointer): integer; cdecl;
     function Set_AutoTranslate(AValue: PPyObject; AContext: Pointer): integer; cdecl;
@@ -526,6 +527,12 @@ begin
   Result := GetPythonEngine.PyUnicodeFromString(DelphiObject.StyleLookup);
 end;
 
+function TPyDelphiStyledControl.Get_StyleState(AContext: Pointer): PPyObject;
+begin
+  Adjust(@Self);
+  Result := GetPythonEngine.PyLong_FromLong(Ord(DelphiObject.StyleState));
+end;
+
 function TPyDelphiStyledControl.Inflate_Wrapper(args: PPyObject): PPyObject;
 begin
   Adjust(@Self);
@@ -566,6 +573,8 @@ begin
     AddGetSet('AdjustType', @TPyDelphiStyledControl.Get_AdjustType, nil,
       'Determines if and how the width and height of this control should be '
       + 'modified to take the fixed space dictated by the style of this control', nil);
+    AddGetSet('StyleState', @TPyDelphiStyledControl.Get_StyleState, nil,
+      'This property allows you to define the current state of style', nil);
   end;
 end;
 

--- a/Source/fmx/WrapFmxControls.pas
+++ b/Source/fmx/WrapFmxControls.pas
@@ -31,6 +31,7 @@ type
     function CanFocus_Wrapper(args: PPyObject): PPyObject; cdecl;
     function SetFocus_Wrapper(args: PPyObject): PPyObject; cdecl;
     function ResetFocus_Wrapper(args: PPyObject): PPyObject; cdecl;
+    function PrepareForPaint_Wrapper(args : PPyObject) : PPyObject; cdecl;
     // Property Getters
     function Get_Visible(AContext: Pointer): PPyObject; cdecl;
     function Get_ControlsCount( AContext : Pointer) : PPyObject; cdecl;
@@ -148,6 +149,18 @@ begin
   end;
 end;
 
+function TPyDelphiControl.PrepareForPaint_Wrapper(args: PPyObject): PPyObject;
+begin
+  Adjust(@Self);
+  with GetPythonEngine do begin
+    if PyArg_ParseTuple( args, ':PrepareForPaint') <> 0 then begin
+      DelphiObject.PrepareForPaint;
+      Result := ReturnNone;
+    end else
+      Result := nil;
+  end;
+end;
+
 class function TPyDelphiControl.DelphiObjectClass: TClass;
 begin
   Result := TControl;
@@ -241,6 +254,9 @@ begin
   PythonType.AddMethod('ResetFocus', @TPyDelphiControl.ResetFocus_Wrapper,
     'TControl.ResetFocus()'#10 +
     'Removes the focus from a control of from any children of the control.');
+  PythonType.AddMethod('PrepareForPaint', @TPyDelphiControl.PrepareForPaint_Wrapper,
+    'TControl.PrepareForPaint()'#10 +
+    'Prepares the current control for painting.');
 end;
 
 function TPyDelphiControl.Repaint_Wrapper(args: PPyObject): PPyObject;

--- a/Source/fmx/WrapFmxControls.pas
+++ b/Source/fmx/WrapFmxControls.pas
@@ -37,8 +37,10 @@ type
     function Get_Controls(AContext: Pointer): PPyObject; cdecl;
     function Get_IsFocused( AContext : Pointer) : PPyObject; cdecl;
     function Get_ParentControl( AContext : Pointer) : PPyObject; cdecl;
+    function Get_Position(AContext: Pointer): PPyObject; cdecl;
     // Property Setters
     function Set_Visible(AValue: PPyObject; AContext: Pointer): integer; cdecl;
+    function Set_Position(AValue: PPyObject; AContext: Pointer): integer; cdecl;
   public
     class function  DelphiObjectClass : TClass; override;
     class procedure RegisterGetSets( PythonType : TPythonType ); override;
@@ -161,6 +163,12 @@ begin
   Result := Wrap(DelphiObject.ParentControl);
 end;
 
+function TPyDelphiControl.Get_Position(AContext: Pointer): PPyObject;
+begin
+  Adjust(@Self);
+  Result := Wrap(DelphiObject.Position);
+end;
+
 function TPyDelphiControl.Get_Visible(AContext: Pointer): PPyObject;
 begin
   Adjust(@Self);
@@ -178,6 +186,8 @@ begin
         'Returns an iterator over contained controls', nil);
   PythonType.AddGetSet('IsFocused', @TPyDelphiControl.Get_IsFocused, nil,
         'Determines whether the control has input focus.', nil);
+  PythonType.AddGetSet('Position', @TPyDelphiControl.Get_Position, @TPyDelphiControl.Set_Position,
+        'Returns an access to the position of the control inside its parent', nil);
 end;
 
 class procedure TPyDelphiControl.RegisterMethods(PythonType: TPythonType);
@@ -302,6 +312,21 @@ begin
     end else
       Result := nil;
   end;
+end;
+
+function TPyDelphiControl.Set_Position(AValue: PPyObject;
+  AContext: Pointer): integer;
+var
+  LValue: TObject;
+begin
+  Adjust(@Self);
+  if CheckObjAttribute(AValue, 'Position', TPosition, LValue) then
+  begin
+    DelphiObject.Position := TPosition(LValue);
+    Result := 0;
+  end
+  else
+    Result := -1;
 end;
 
 function TPyDelphiControl.Set_Visible(AValue: PPyObject;

--- a/Source/fmx/WrapFmxControls.pas
+++ b/Source/fmx/WrapFmxControls.pas
@@ -74,6 +74,7 @@ type
   protected
     // Exposed Methods
     // Property Getters
+    function Get_DefaultStyleLookupName(AContext: Pointer): PPyObject; cdecl;
     function Get_StyleLookup(AContext: Pointer): PPyObject; cdecl;
     // Property Setters
     function Set_StyleLookup(AValue: PPyObject; AContext: Pointer): integer; cdecl;
@@ -457,6 +458,13 @@ begin
   Result := TStyledControl(inherited DelphiObject);
 end;
 
+function TPyDelphiStyledControl.Get_DefaultStyleLookupName(
+  AContext: Pointer): PPyObject;
+begin
+  Adjust(@Self);
+  Result := GetPythonEngine.PyUnicodeFromString(DelphiObject.DefaultStyleLookupName);
+end;
+
 function TPyDelphiStyledControl.Get_StyleLookup(AContext: Pointer): PPyObject;
 begin
   Adjust(@Self);
@@ -467,8 +475,10 @@ class procedure TPyDelphiStyledControl.RegisterGetSets(PythonType: TPythonType);
 begin
   inherited;
   with PythonType do begin
+    AddGetSet('DefaultStyleLookupName', @TPyDelphiStyledControl.Get_StyleLookup, nil,
+      'Provides access to the default style lookup name of a StyledControl', nil);
     AddGetSet('StyleLookup', @TPyDelphiStyledControl.Get_StyleLookup, @TPyDelphiStyledControl.Set_StyleLookup,
-      'Provides access to the StyleLookup of a StyledControl', nil);
+      'Provides access to the style lookup of a StyledControl', nil);
   end;
 end;
 

--- a/Source/fmx/WrapFmxControls.pas
+++ b/Source/fmx/WrapFmxControls.pas
@@ -75,6 +75,7 @@ type
     // Exposed Methods
     function ApplyStyleLookup_Wrapper(args : PPyObject) : PPyObject; cdecl;
     function NeedStyleLookup_Wrapper(args : PPyObject) : PPyObject; cdecl;
+    function Inflate_Wrapper(args : PPyObject) : PPyObject; cdecl;
     // Property Getters
     function Get_DefaultStyleLookupName(AContext: Pointer): PPyObject; cdecl;
     function Get_StyleLookup(AContext: Pointer): PPyObject; cdecl;
@@ -494,6 +495,18 @@ begin
   Result := GetPythonEngine.PyUnicodeFromString(DelphiObject.StyleLookup);
 end;
 
+function TPyDelphiStyledControl.Inflate_Wrapper(args: PPyObject): PPyObject;
+begin
+  Adjust(@Self);
+  with GetPythonEngine do begin
+    if PyArg_ParseTuple( args, ':Inflate') <> 0 then begin
+      DelphiObject.Inflate;
+      Result := ReturnNone;
+    end else
+      Result := nil;
+  end;
+end;
+
 function TPyDelphiStyledControl.NeedStyleLookup_Wrapper(
   args: PPyObject): PPyObject;
 begin
@@ -529,6 +542,9 @@ begin
   PythonType.AddMethod('NeedStyleLookup', @TPyDelphiStyledControl.NeedStyleLookup_Wrapper,
     'TStyledControl.NeedStyleLookup()'#10 +
     'Call this procedure to indicate that this control requires to get and apply its style lookup.');
+  PythonType.AddMethod('Inflate', @TPyDelphiStyledControl.Inflate_Wrapper,
+    'TStyledControl.Inflate()'#10 +
+    'Call this procedure to get and apply its style lookup.');
 end;
 
 procedure TPyDelphiStyledControl.SetDelphiObject(const Value: TStyledControl);

--- a/Source/fmx/WrapFmxControls.pas
+++ b/Source/fmx/WrapFmxControls.pas
@@ -81,6 +81,7 @@ type
     function Get_DefaultStyleLookupName(AContext: Pointer): PPyObject; cdecl;
     function Get_StyleLookup(AContext: Pointer): PPyObject; cdecl;
     function Get_AutoTranslate(AContext: Pointer): PPyObject; cdecl;
+    function Get_AdjustSizeValue(AContext: Pointer): PPyObject; cdecl;
     // Property Setters
     function Set_StyleLookup(AValue: PPyObject; AContext: Pointer): integer; cdecl;
     function Set_AutoTranslate(AValue: PPyObject; AContext: Pointer): integer; cdecl;
@@ -492,6 +493,13 @@ begin
   Result := TStyledControl(inherited DelphiObject);
 end;
 
+function TPyDelphiStyledControl.Get_AdjustSizeValue(
+  AContext: Pointer): PPyObject;
+begin
+  Adjust(@Self);
+  Result := WrapSizeF(PyDelphiWrapper, DelphiObject.AdjustSizeValue);
+end;
+
 function TPyDelphiStyledControl.Get_AutoTranslate(AContext: Pointer): PPyObject;
 begin
   Adjust(@Self);
@@ -546,6 +554,8 @@ begin
       'Specifies the name of the resource object to which the current TStyledControl is linked', nil);
     AddGetSet('AutoTranslate', @TPyDelphiStyledControl.Get_AutoTranslate, @TPyDelphiStyledControl.Set_AutoTranslate,
       'Specifies whether the control''s text should be translated', nil);
+    AddGetSet('AdjustSizeValue', @TPyDelphiStyledControl.Get_AdjustSizeValue, nil,
+      'Updates the width and height of this control according to its current style', nil);
   end;
 end;
 

--- a/Source/fmx/WrapFmxControls.pas
+++ b/Source/fmx/WrapFmxControls.pas
@@ -6,7 +6,7 @@ interface
 
 uses
   Classes, SysUtils, TypInfo, Types,
-  Fmx.Controls,
+  FMX.Types, FMX.Controls,
   PythonEngine, WrapDelphi, WrapDelphiClasses, WrapFmxTypes;
 
 type
@@ -67,10 +67,25 @@ type
     property Container : TControl read GetContainer;
   end;
 
-implementation
+  TPyDelphiStyledControl = class(TPyDelphiControl)
+  private
+    function GetDelphiObject: TStyledControl;
+    procedure SetDelphiObject(const Value: TStyledControl);
+  protected
+    // Exposed Methods
+    // Property Getters
+    function Get_StyleLookup(AContext: Pointer): PPyObject; cdecl;
+    // Property Setters
+    function Set_StyleLookup(AValue: PPyObject; AContext: Pointer): integer; cdecl;
+  public
+    class function DelphiObjectClass: TClass; override;
+    class procedure RegisterGetSets(PythonType: TPythonType); override;
+    class procedure RegisterMethods(PythonType: TPythonType); override;
+    // Properties
+    property DelphiObject: TStyledControl read GetDelphiObject write SetDelphiObject;
+  end;
 
-uses
-  FMX.Types;
+implementation
 
 type
 { Register the wrappers, the globals and the constants }
@@ -427,6 +442,54 @@ end;
 class function TControlsAccess.SupportsIndexOf: Boolean;
 begin
   Result := True;
+end;
+
+{ TPyDelphiStyledControl }
+
+class function TPyDelphiStyledControl.DelphiObjectClass: TClass;
+begin
+  Result := TStyledControl;
+end;
+
+function TPyDelphiStyledControl.GetDelphiObject: TStyledControl;
+begin
+  Result := TStyledControl(inherited DelphiObject);
+end;
+
+function TPyDelphiStyledControl.Get_StyleLookup(AContext: Pointer): PPyObject;
+begin
+  Adjust(@Self);
+  Result := GetPythonEngine.PyUnicodeFromString(DelphiObject.StyleLookup);
+end;
+
+class procedure TPyDelphiStyledControl.RegisterGetSets(PythonType: TPythonType);
+begin
+  inherited;
+end;
+
+class procedure TPyDelphiStyledControl.RegisterMethods(PythonType: TPythonType);
+begin
+  inherited;
+end;
+
+procedure TPyDelphiStyledControl.SetDelphiObject(const Value: TStyledControl);
+begin
+  inherited DelphiObject := Value;
+end;
+
+function TPyDelphiStyledControl.Set_StyleLookup(AValue: PPyObject;
+  AContext: Pointer): integer;
+var
+  LValue: string;
+begin
+  if CheckStrAttribute(AValue, 'StyleLookup', LValue) then
+    with GetPythonEngine do begin
+      Adjust(@Self);
+      DelphiObject.StyleLookup := LValue;
+      Result := 0;
+    end
+    else
+      Result := -1;
 end;
 
 initialization

--- a/Source/fmx/WrapFmxControls.pas
+++ b/Source/fmx/WrapFmxControls.pas
@@ -73,6 +73,7 @@ type
     procedure SetDelphiObject(const Value: TStyledControl);
   protected
     // Exposed Methods
+    function ApplyStyleLookup_Wrapper(args : PPyObject) : PPyObject; cdecl;
     // Property Getters
     function Get_DefaultStyleLookupName(AContext: Pointer): PPyObject; cdecl;
     function Get_StyleLookup(AContext: Pointer): PPyObject; cdecl;
@@ -450,6 +451,19 @@ end;
 
 { TPyDelphiStyledControl }
 
+function TPyDelphiStyledControl.ApplyStyleLookup_Wrapper(
+  args: PPyObject): PPyObject;
+begin
+  Adjust(@Self);
+  with GetPythonEngine do begin
+    if PyArg_ParseTuple( args, ':ApplyStyleLookup') <> 0 then begin
+      DelphiObject.ApplyStyleLookup;
+      Result := ReturnNone;
+    end else
+      Result := nil;
+  end;
+end;
+
 class function TPyDelphiStyledControl.DelphiObjectClass: TClass;
 begin
   Result := TStyledControl;
@@ -495,6 +509,9 @@ end;
 class procedure TPyDelphiStyledControl.RegisterMethods(PythonType: TPythonType);
 begin
   inherited;
+  PythonType.AddMethod('ApplyStyleLookup', @TPyDelphiStyledControl.ApplyStyleLookup_Wrapper,
+    'TStyledControl.ApplyStyleLookup()'#10 +
+    'Gets and applies the style of a TStyledControl.');
 end;
 
 procedure TPyDelphiStyledControl.SetDelphiObject(const Value: TStyledControl);

--- a/Source/fmx/WrapFmxControls.pas
+++ b/Source/fmx/WrapFmxControls.pas
@@ -74,6 +74,7 @@ type
   protected
     // Exposed Methods
     function ApplyStyleLookup_Wrapper(args : PPyObject) : PPyObject; cdecl;
+    function NeedStyleLookup_Wrapper(args : PPyObject) : PPyObject; cdecl;
     // Property Getters
     function Get_DefaultStyleLookupName(AContext: Pointer): PPyObject; cdecl;
     function Get_StyleLookup(AContext: Pointer): PPyObject; cdecl;
@@ -493,6 +494,19 @@ begin
   Result := GetPythonEngine.PyUnicodeFromString(DelphiObject.StyleLookup);
 end;
 
+function TPyDelphiStyledControl.NeedStyleLookup_Wrapper(
+  args: PPyObject): PPyObject;
+begin
+  Adjust(@Self);
+  with GetPythonEngine do begin
+    if PyArg_ParseTuple( args, ':NeedStyleLookup') <> 0 then begin
+      DelphiObject.NeedStyleLookup;
+      Result := ReturnNone;
+    end else
+      Result := nil;
+  end;
+end;
+
 class procedure TPyDelphiStyledControl.RegisterGetSets(PythonType: TPythonType);
 begin
   inherited;
@@ -512,6 +526,9 @@ begin
   PythonType.AddMethod('ApplyStyleLookup', @TPyDelphiStyledControl.ApplyStyleLookup_Wrapper,
     'TStyledControl.ApplyStyleLookup()'#10 +
     'Gets and applies the style of a TStyledControl.');
+  PythonType.AddMethod('NeedStyleLookup', @TPyDelphiStyledControl.NeedStyleLookup_Wrapper,
+    'TStyledControl.NeedStyleLookup()'#10 +
+    'Call this procedure to indicate that this control requires to get and apply its style lookup.');
 end;
 
 procedure TPyDelphiStyledControl.SetDelphiObject(const Value: TStyledControl);

--- a/Source/fmx/WrapFmxTypes.pas
+++ b/Source/fmx/WrapFmxTypes.pas
@@ -34,6 +34,28 @@ type
     property Value : TPointF read FValue write FValue;
   end;
 
+  TPyDelphiSizeF = class(TPyObject)
+  private
+    FValue: TSizeF;
+  protected
+    // Exposed Getters
+    function Get_Width(Acontext: Pointer): PPyObject; cdecl;
+    function Get_Height(Acontext: Pointer): PPyObject; cdecl;
+    // Exposed Setters
+    function Set_Width(AValue: PPyObject; AContext: Pointer): integer; cdecl;
+    function Set_Height(AValue: PPyObject; AContext: Pointer): integer; cdecl;
+  public
+    constructor CreateWith(APythonType: TPythonType; args: PPyObject); override;
+
+    function Compare(obj: PPyObject): Integer; override;
+    function Repr: PPyObject; override;
+
+    class procedure RegisterGetSets(PythonType: TPythonType); override;
+    class procedure SetupType(PythonType: TPythonType); override;
+
+    property Value : TSizeF read FValue write FValue;
+  end;
+
   TPyDelphiFmxObject = class(TPyDelphiComponent)
   private
     function GetDelphiObject: TFmxObject;
@@ -74,7 +96,9 @@ type
 
   {Helper functions}
   function WrapPointF(APyDelphiWrapper: TPyDelphiWrapper; const APoint : TPointF) : PPyObject;
+  function WrapSizeF(APyDelphiWrapper: TPyDelphiWrapper; const ASize : TSizeF) : PPyObject;
   function CheckPointFAttribute(AAttribute : PPyObject; const AAttributeName : string; out AValue : TPointF) : Boolean;
+  function CheckSizeFAttribute(AAttribute : PPyObject; const AAttributeName : string; out AValue : TSizeF) : Boolean;
 
 implementation
 
@@ -206,6 +230,7 @@ procedure TTypesRegistration.RegisterWrappers(
 begin
   inherited;
   APyDelphiWrapper.RegisterHelperType(TPyDelphiPointF);
+  APyDelphiWrapper.RegisterHelperType(TPyDelphiSizeF);
   APyDelphiWrapper.RegisterDelphiWrapper(TPyDelphiFmxObject);
   APyDelphiWrapper.RegisterDelphiWrapper(TPyDelphiPosition);
 end;
@@ -218,6 +243,15 @@ begin
   _type := APyDelphiWrapper.GetHelperType('PointFType');
   Result := _type.CreateInstance;
   (PythonToDelphi(Result) as TPyDelphiPointF).Value := APoint;
+end;
+
+function WrapSizeF(APyDelphiWrapper: TPyDelphiWrapper; const ASize : TSizeF) : PPyObject;
+var
+  LType : TPythonType;
+begin
+  LType := APyDelphiWrapper.GetHelperType('SizeFType');
+  Result := LType.CreateInstance;
+  (PythonToDelphi(Result) as TPyDelphiSizeF).Value := ASize;
 end;
 
 function CheckPointFAttribute(AAttribute : PPyObject; const AAttributeName : string; out AValue : TPointF) : Boolean;
@@ -235,6 +269,25 @@ begin
       with GetPythonEngine do
         PyErr_SetString (PyExc_AttributeError^,
           PAnsiChar(AnsiString(Format('%s receives only PointF objects', [AAttributeName]))));
+    end;
+  end;
+end;
+
+function CheckSizeFAttribute(AAttribute : PPyObject; const AAttributeName : string; out AValue : TSizeF) : Boolean;
+begin
+  with GetPythonEngine do
+  begin
+    if IsDelphiObject(AAttribute) and (PythonToDelphi(AAttribute) is TPyDelphiSizeF) then
+    begin
+      AValue := TPyDelphiSizeF(PythonToDelphi(AAttribute)).Value;
+      Result := True;
+    end
+    else
+    begin
+      Result := False;
+      with GetPythonEngine do
+        PyErr_SetString (PyExc_AttributeError^,
+          PAnsiChar(AnsiString(Format('%s receives only SizeF objects', [AAttributeName]))));
     end;
   end;
 end;
@@ -379,6 +432,107 @@ begin
     with GetPythonEngine do begin
       Adjust(@Self);
       DelphiObject.Y := y;
+      Result := 0;
+    end
+    else
+      Result := -1;
+end;
+
+{ TPyDelphiSizeF }
+
+function TPyDelphiSizeF.Compare(obj: PPyObject): Integer;
+var
+  LOther : TPyDelphiSizeF;
+begin
+  if IsDelphiObject(obj) and (PythonToDelphi(obj) is TPyDelphiPointF) then
+  begin
+    LOther := TPyDelphiSizeF(PythonToDelphi(obj));
+    Result := CompareValue(Value.Width, LOther.Value.Width);
+    if Result = 0 then
+      Result := CompareValue(Value.Height, LOther.Value.Height);
+  end
+  else
+    Result := 1;
+end;
+
+constructor TPyDelphiSizeF.CreateWith(APythonType: TPythonType;
+  args: PPyObject);
+var
+  LWidth, LHeight : single;
+begin
+  inherited;
+  if APythonType.Engine.PyArg_ParseTuple(args, 'ff:Create', @LWidth, @LHeight) <> 0 then
+  begin
+   FValue.Width := LWidth;
+   FValue.Height := LHeight;
+  end
+end;
+
+function TPyDelphiSizeF.Get_Height(Acontext: Pointer): PPyObject;
+begin
+  Adjust(@Self);
+  Result := GetPythonEngine.PyFloat_FromDouble(Value.Height);
+end;
+
+function TPyDelphiSizeF.Get_Width(Acontext: Pointer): PPyObject;
+begin
+  Adjust(@Self);
+  Result := GetPythonEngine.PyFloat_FromDouble(Value.Width);
+end;
+
+class procedure TPyDelphiSizeF.RegisterGetSets(PythonType: TPythonType);
+begin
+  inherited;
+  with PythonType do
+    begin
+      AddGetSet('Width', @TPyDelphiSizeF.Get_Width, @TPyDelphiSizeF.Set_Width,
+        'Provides access to the width of a sizef', nil);
+      AddGetSet('Height', @TPyDelphiSizeF.Get_Height, @TPyDelphiSizeF.Set_Height,
+        'Provides access to the height of a sizef', nil);
+    end;
+end;
+
+function TPyDelphiSizeF.Repr: PPyObject;
+begin
+  Result := GetPythonEngine.PyUnicodeFromString(Format('<SizeF (%f, %f)>',
+    [Value.Width, Value.Height]));
+end;
+
+class procedure TPyDelphiSizeF.SetupType(PythonType: TPythonType);
+begin
+  inherited;
+  PythonType.TypeName := 'SizeF';
+  PythonType.Name := string(PythonType.TypeName) + 'Type';
+  PythonType.TypeFlags := PythonType.TypeFlags + [tpfBaseType];
+  PythonType.GenerateCreateFunction := False;
+  PythonType.DocString.Text := 'wrapper for Delphi FMX TSizeF type';
+  PythonType.Services.Basic := [bsGetAttrO, bsSetAttrO, bsRepr, bsStr, bsRichCompare];
+end;
+
+function TPyDelphiSizeF.Set_Height(AValue: PPyObject;
+  AContext: Pointer): integer;
+var
+  LValue: double;
+begin
+  if CheckFloatAttribute(AValue, 'Height', LValue) then
+    with GetPythonEngine do begin
+      Adjust(@Self);
+      FValue.Height := LValue;
+      Result := 0;
+    end
+    else
+      Result := -1;
+end;
+
+function TPyDelphiSizeF.Set_Width(AValue: PPyObject;
+  AContext: Pointer): integer;
+var
+  LValue: double;
+begin
+  if CheckFloatAttribute(AValue, 'Width', LValue) then
+    with GetPythonEngine do begin
+      Adjust(@Self);
+      FValue.Width := LValue;
       Result := 0;
     end
     else


### PR DESCRIPTION
**FMX.Types.TPosition wrapper**
* TSizeF represents the floating-point size of an object using the Width and Height properties (will be allocated in WrapSysTypes)

**FMX.Controls.TStyledControl wrapper**
* DefaultStyleLookupName property access;
* StyleLookup property access;
* AutoTranslate property access;
* AdjustSizeValue property access;
* AdjustType property access;
* StyleState property access;
* ApplyStyleLookup method access;
* NeedStyleLookup method access;
* Inflate method access.
