### PR TITLE
Fmxcontrolswrappers

### DIFF
--- a/Source/fmx/WrapFmxControls.pas
+++ b/Source/fmx/WrapFmxControls.pas
@@ -105,6 +105,16 @@ type
     property DelphiObject: TTextControl read GetDelphiObject write SetDelphiObject;
   end;
 
+  TPyDelphiStyleBook = class(TPyDelphiFmxObject)
+  private
+    function GetDelphiObject: TStyleBook;
+    procedure SetDelphiObject(const Value: TStyleBook);
+  public
+    class function DelphiObjectClass: TClass; override;
+    // Properties
+    property DelphiObject: TStyleBook read GetDelphiObject write SetDelphiObject;
+  end;
+
 implementation
 
 type
@@ -413,6 +423,7 @@ begin
   APyDelphiWrapper.RegisterDelphiWrapper(TPyDelphiControl);
   APyDelphiWrapper.RegisterDelphiWrapper(TPyDelphiStyledControl);
   APyDelphiWrapper.RegisterDelphiWrapper(TPyDelphiTextControl);
+  APyDelphiWrapper.RegisterDelphiWrapper(TPyDelphiStyleBook);
 end;
 
 { TControlsAccess }
@@ -651,6 +662,23 @@ begin
 end;
 
 procedure TPyDelphiTextControl.SetDelphiObject(const Value: TTextControl);
+begin
+  inherited DelphiObject := Value;
+end;
+
+{ TPyDelphiStyleBook }
+
+class function TPyDelphiStyleBook.DelphiObjectClass: TClass;
+begin
+  Result := TStyleBook;
+end;
+
+function TPyDelphiStyleBook.GetDelphiObject: TStyleBook;
+begin
+  Result := TStyleBook(inherited DelphiObject);
+end;
+
+procedure TPyDelphiStyleBook.SetDelphiObject(const Value: TStyleBook);
 begin
   inherited DelphiObject := Value;
 end;

--- a/Source/fmx/WrapFmxControls.pas
+++ b/Source/fmx/WrapFmxControls.pas
@@ -115,6 +115,16 @@ type
     property DelphiObject: TStyleBook read GetDelphiObject write SetDelphiObject;
   end;
 
+  TPyDelphiPopup = class(TPyDelphiStyledControl)
+  private
+    function GetDelphiObject: TPopup;
+    procedure SetDelphiObject(const Value: TPopup);
+  public
+    class function DelphiObjectClass: TClass; override;
+    // Properties
+    property DelphiObject: TPopup read GetDelphiObject write SetDelphiObject;
+  end;
+
 implementation
 
 type
@@ -679,6 +689,23 @@ begin
 end;
 
 procedure TPyDelphiStyleBook.SetDelphiObject(const Value: TStyleBook);
+begin
+  inherited DelphiObject := Value;
+end;
+
+{ TPyDelphiPopup }
+
+class function TPyDelphiPopup.DelphiObjectClass: TClass;
+begin
+  Result := TPopup;
+end;
+
+function TPyDelphiPopup.GetDelphiObject: TPopup;
+begin
+  Result := TPopup(inherited DelphiObject);
+end;
+
+procedure TPyDelphiPopup.SetDelphiObject(const Value: TPopup);
 begin
   inherited DelphiObject := Value;
 end;

--- a/Source/fmx/WrapFmxControls.pas
+++ b/Source/fmx/WrapFmxControls.pas
@@ -95,6 +95,16 @@ type
     property DelphiObject: TStyledControl read GetDelphiObject write SetDelphiObject;
   end;
 
+  TPyDelphiTextControl = class(TPyDelphiStyledControl)
+  private
+    function GetDelphiObject: TTextControl;
+    procedure SetDelphiObject(const Value: TTextControl);
+  public
+    class function DelphiObjectClass: TClass; override;
+    // Properties
+    property DelphiObject: TTextControl read GetDelphiObject write SetDelphiObject;
+  end;
+
 implementation
 
 type
@@ -402,6 +412,7 @@ begin
   inherited;
   APyDelphiWrapper.RegisterDelphiWrapper(TPyDelphiControl);
   APyDelphiWrapper.RegisterDelphiWrapper(TPyDelphiStyledControl);
+  APyDelphiWrapper.RegisterDelphiWrapper(TPyDelphiTextControl);
 end;
 
 { TControlsAccess }
@@ -625,6 +636,23 @@ begin
     end
     else
       Result := -1;
+end;
+
+{ TPyDelphiTextControl }
+
+class function TPyDelphiTextControl.DelphiObjectClass: TClass;
+begin
+  Result := TTextControl;
+end;
+
+function TPyDelphiTextControl.GetDelphiObject: TTextControl;
+begin
+  Result := TTextControl(inherited DelphiObject);
+end;
+
+procedure TPyDelphiTextControl.SetDelphiObject(const Value: TTextControl);
+begin
+  inherited DelphiObject := Value;
 end;
 
 initialization

--- a/Source/fmx/WrapFmxControls.pas
+++ b/Source/fmx/WrapFmxControls.pas
@@ -434,6 +434,7 @@ begin
   APyDelphiWrapper.RegisterDelphiWrapper(TPyDelphiStyledControl);
   APyDelphiWrapper.RegisterDelphiWrapper(TPyDelphiTextControl);
   APyDelphiWrapper.RegisterDelphiWrapper(TPyDelphiStyleBook);
+  APyDelphiWrapper.RegisterDelphiWrapper(TPyDelphiPopup);
 end;
 
 { TControlsAccess }


### PR DESCRIPTION
**FMX.Controls.TTextControl wrapper**
* Specifies the text that will be rendered over the surface of this TTextControl object.

**FMX.Controls.TStyleBook wrapper**
* TStyleBook stores a collection of styles for a form.

**FMX.Controls.TPopup wrapper**
* TPopup provides a pop-up window.