### PR TITLE
isatty method in DebugOutput class for better compability

### DIFF
--- a/Source/PythonEngine.pas
+++ b/Source/PythonEngine.pas
@@ -4836,6 +4836,8 @@ const
          '     return self.pyio.read(size)'+LF+
          '  def flush(self):' + LF +
          '     pass' + LF +
+         '  def isatty(self):' + LF +
+         '     return True' + LF +
          'sys.old_stdin=sys.stdin'+LF+
          'sys.old_stdout=sys.stdout'+LF+
          'sys.old_stderr=sys.stderr'+LF+


### PR DESCRIPTION
I need to be dependencies automatically satisfied for user scripts, but pip module requires this method in stdout.

Fixed by two lines:)