### PR TITLE
rtti invoke - variant parameter with array inside

### DIFF
--- a/Source/WrapDelphi.pas
+++ b/Source/WrapDelphi.pas
@@ -1040,15 +1040,13 @@ begin
           Value := V.Cast(TypeInfo);
           Result := True;
         end;
-      tkInteger, tkFloat, tkInt64:
+      tkInteger, tkFloat, tkInt64, tkVariant:
         begin
-          V :=  TValue.FromVariant(GetPythonEngine.PyObjectAsVariant(PyValue));
-          Value := V.Cast(TypeInfo);
-          Result := True;
-        end;
-      tkVariant:
-        begin
-          Value :=  TValue.From<Variant>(GetPythonEngine.PyObjectAsVariant(PyValue));
+          V := TValue.From<Variant>(GetPythonEngine.PyObjectAsVariant(PyValue));
+          if TypeInfo^.Kind = tkVariant then
+            Value := V
+          else
+            Value := V.Cast(TypeInfo);
           Result := True;
         end;
       tkEnumeration:

--- a/Source/WrapDelphi.pas
+++ b/Source/WrapDelphi.pas
@@ -1040,11 +1040,15 @@ begin
           Value := V.Cast(TypeInfo);
           Result := True;
         end;
-      tkInteger, tkFloat, tkInt64,
-      tkVariant:
+      tkInteger, tkFloat, tkInt64:
         begin
           V :=  TValue.FromVariant(GetPythonEngine.PyObjectAsVariant(PyValue));
           Value := V.Cast(TypeInfo);
+          Result := True;
+        end;
+      tkVariant:
+        begin
+          Value :=  TValue.From<Variant>(GetPythonEngine.PyObjectAsVariant(PyValue));
           Result := True;
         end;
       tkEnumeration:

--- a/Tests/WrapDelphiTest.pas
+++ b/Tests/WrapDelphiTest.pas
@@ -57,6 +57,7 @@ type
     property Fruits: TFruits read FFruits write FFruits;
     function SetStringField(var Value: Integer): string; overload;
     function SetStringField(const Value: string): string; overload;
+    procedure PassVariantArray(const Value: Variant);
   end;
 
   TTestInterfaceImpl = class(TInterfacedObject, ITestInterface)
@@ -118,7 +119,9 @@ type
     [Test]
     procedure TestMethodWithVarAndOverload;
     [Test]
-    procedure FreeReturnedObject;
+    procedure TestFreeReturnedObject;
+    [Test]
+    procedure TestPassVariantArray;
   end;
 
 implementation
@@ -142,7 +145,7 @@ end;
 
 { TTestVarPyth }
 
-procedure TTestWrapDelphi.FreeReturnedObject;
+procedure TTestWrapDelphi.TestFreeReturnedObject;
 begin
   PythonEngine.ExecString(
     'from delphi import rtti_var' + sLineBreak +
@@ -333,6 +336,15 @@ begin
   Assert.IsTrue(rtti_var.ObjectField = None);
 end;
 
+procedure TTestWrapDelphi.TestPassVariantArray;
+begin
+  PythonEngine.ExecString(
+    'from delphi import rtti_var' + sLineBreak +
+    'rtti_var.PassVariantArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])'
+    );
+  Assert.Pass;
+end;
+
 procedure TTestWrapDelphi.TestRecord;
 begin
   Rtti_rec.StringField := 'abcd';
@@ -450,6 +462,11 @@ var
 begin
   for I := 0 to Length(Result) - 1 do
     Result[I] := I;
+end;
+
+procedure TTestRttiAccess.PassVariantArray(const Value: Variant);
+begin
+  Assert.IsTrue(VarIsArray(Value) and (VarArrayHighBound(Value, 1) = 9));
 end;
 
 procedure TTestRttiAccess.SellFruits(const AFruits: TFruitDynArray);


### PR DESCRIPTION
hi - this is another fix for a situation if I try to call via rtti a method like this
pas: 
`  procedure PassVariantArray(const Value: Variant);`
with list as parameter
py: 
`  rtti_var.PassVariantArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])`
but I got an exception - "Invalid variant type conversion" in SimplePythonToValue->TValue.FromVariant. This method(FromVariant) is ok for simple types but array should stay "as is" in Variant.
