### PR TITLE
PythonVersionFromPath.FindPythonDLL support for Python>=3.10

### DIFF
--- a/Source/PythonVersions.pas
+++ b/Source/PythonVersions.pas
@@ -435,21 +435,18 @@ function PythonVersionFromPath(const Path: string; out PythonVersion: TPythonVer
 
   function FindPythonDLL(APath : string): string;
   Var
-    FindFileData: TWIN32FindData;
-    Handle : THandle;
     DLLFileName: string;
+    I: integer;
   begin
     Result := '';
-    Handle := FindFirstFile(PWideChar(APath+'\python??.dll'), FindFileData);
-    if Handle = INVALID_HANDLE_VALUE then Exit;  // not python dll
-    DLLFileName:= FindFileData.cFileName;
-    // skip if python3.dll was found
-    if Length(DLLFileName) <> 12 then FindNextFile(Handle, FindFileData);
-    if Handle = INVALID_HANDLE_VALUE then Exit;
-    Windows.FindClose(Handle);
-    DLLFileName:= FindFileData.cFileName;
-    if Length(DLLFileName) = 12 then
-      Result := DLLFileName;
+    APath := IncludeTrailingPathDelimiter(APath);
+    for I := High(PYTHON_KNOWN_VERSIONS) downto COMPILED_FOR_PYTHON_VERSION_INDEX do begin
+      DLLFileName := PYTHON_KNOWN_VERSIONS[I].DLLName;
+      if FileExists(APath+DLLFileName) then begin
+        Result := DLLFileName;
+        exit;
+      end;
+    end;
   end;
 
   function GetVenvBasePrefix(InstallPath: string): string;


### PR DESCRIPTION
Currently PythonVersions.pas - PythonVersionFromPath.FindPythonDLL only supports `Python??.dll` (Python<3.10).
With this PR it will only search for supported versions of Python (and also support >=v3.10).

Some old distributions of `OSGeo4W` also distribute Python2 + Python36 in the same folder, although this configuration is not recommended, this fix will also load correctly Python36 in this case.