### PR TITLE
PyGILState_Release correction

### DIFF
--- a/Source/PythonEngine.pas
+++ b/Source/PythonEngine.pas
@@ -765,6 +765,9 @@ const
 
   { # of bytes for year, month, day, hour, minute, second, and usecond. }
   _PyDateTime_DATETIME_DATASIZE = 10;
+  PyGILState_LOCKED = 0;
+  PyGILState_UNLOCKED = 1;
+
 type
   PyDateTime_Delta = {$IFNDEF CPUX64}packed{$ENDIF} record
     // Start of the Head of an object
@@ -914,7 +917,7 @@ type
 //##         GIL state                                 ##
 //##                                                   ##
 //#######################################################
-  PyGILState_STATE = (PyGILState_LOCKED, PyGILState_UNLOCKED);
+  PyGILState_STATE = type Integer; // (PyGILState_LOCKED, PyGILState_UNLOCKED);
 
 //#######################################################
 //##                                                   ##


### PR DESCRIPTION
It's a fix for a problem I found doing threading controlled outside p4d. With optimizations enabled, delphi treats PyGILState_STATE enum as 1-byte by default, but vc++ compiled python.dll has it as a 4-byte enum. Calls to PyGILState_Release with a 1-byte argument (decompiled to something like mov al, 0; call PyGILState_Release;) leads to unexpected behaviour because most significant bytes could have "random" values, depending on what happens to the AX register before calling.
For this fix, I have only internal tests for my system,  but I think it can be important for someone else