### PR TITLE
Rpi5 fix

### DIFF
--- a/Source/MethodCallBack.pas
+++ b/Source/MethodCallBack.pas
@@ -137,7 +137,11 @@ const
   PROT_WRITE  =2;
   PROT_EXEC   =4;
   MAP_PRIVATE =2;
-  MAP_ANON=$20;  
+  {$IFDEF MACOS}
+  MAP_ANON=$1000;
+  {$ELSE}
+  MAP_ANON=$20;
+  {$ENDIF MACOS}
 {$ENDIF}
 {$ENDIF}
 
@@ -754,4 +758,5 @@ finalization
   FreeCallBacks;
 
 end.
+
 


### PR DESCRIPTION
Fix for ARM64 (Raspberry Pi 5) where GetCallBack causes SIGSEGV because
nmap does not allocate executable memory. Added fallback to mmap +
mprotect, corrected literal pool placement, and ensured RX permissions.

Tested on:
- Raspberry Pi 5
- FPC 3.2.2
- Lazarus 4.0
- Python 3.13
- P4D latest

This resolves the callback crash on CPUARM64.