### PR TITLE
Support Unicode paths in Form.LoadProps()

### DIFF
--- a/Modules/DelphiFMX/tests/TestLoadProps.py
+++ b/Modules/DelphiFMX/tests/TestLoadProps.py
@@ -1,5 +1,5 @@
 """
-Comprehensive tests for LoadProps method in DelphiVCL module.
+Comprehensive tests for LoadProps method in DelphiFMX module.
 
 Testing can be run with:
     `python -m unittest discover -s tests -p 'TestLoadProps.py'`
@@ -12,6 +12,8 @@ Tests cover:
 - UTF-8 path handling
 - Edge cases and error conditions
 - PathLike objects with unusual behavior
+
+Cross-platform support: Windows, Linux, macOS, Android
 """
 
 import unittest
@@ -19,34 +21,61 @@ import os
 import sys
 import tempfile
 import shutil
+import platform
 from pathlib import Path
 
-# Ensure DelphiVCL .pyd can be found
+# Ensure DelphiFMX module can be found
 _test_dir = os.path.dirname(os.path.abspath(__file__))
 _module_dir = os.path.dirname(_test_dir)
 
-# Detect platform architecture
+# Detect platform and architecture for cross-platform support
+_system = platform.system()
 _is_64bit = sys.maxsize > 2**32
-_platform_dir = 'Win64' if _is_64bit else 'Win32'
+
+# Detect Android (check for Android-specific indicators)
+_is_android = False
+if hasattr(sys, 'getandroidapilevel'):
+    _is_android = True
+elif 'ANDROID_ROOT' in os.environ or 'ANDROID_DATA' in os.environ:
+    _is_android = True
+elif _system == 'Linux' and os.path.exists('/system/build.prop'):
+    _is_android = True
+
+# Determine platform-specific paths and module extensions
+if _is_android:
+    _platform_dir = 'Android64' if _is_64bit else 'Android'
+elif _system == 'Windows':
+    _platform_dir = 'Win64' if _is_64bit else 'Win32'
+elif _system == 'Linux':
+    _platform_dir = 'Linux64'
+elif _system == 'Darwin':  # macOS
+    _platform_dir = 'OSX64' if _is_64bit else 'OSX32'
+else:
+    raise NotImplementedError(f"Unsupported platform: {_system}")
+
+# Try to find the module in the pyd directory
 _pyd_dir = os.path.join(_module_dir, 'pyd', 'Release', _platform_dir)
 
-# Add pyd directory to sys.path if there is module within and not already there
+# Find and add the directory with the module
 import importlib
 for _module_ext in importlib.machinery.EXTENSION_SUFFIXES:
-    _module_file = os.path.join(_pyd_dir, f'DelphiVCL{_module_ext}')
+    _module_file = os.path.join(_pyd_dir, f'DelphiFMX{_module_ext}')
     if os.path.exists(_module_file):
         if _pyd_dir not in sys.path:
             sys.path.insert(0, _pyd_dir)
         print(f"Module will be loaded from: {_module_file}")
         break
 
+# Import DelphiFMX module - fail loudly if not available
 try:
-    from DelphiVCL import Form
+    from DelphiFMX import Form
 except ImportError as e:
     raise ImportError(
-        f"Failed to import DelphiVCL module. "
+        f"Failed to import DelphiFMX module.\n"
         f"Tried to load from: {_pyd_dir}\n"
-        f"Make sure DelphiVCL.pyd is built and available. "
+        f"Platform: {_system}, Android: {_is_android}, Architecture: {_platform_dir}, Extension: {_module_ext}\n"
+        f"Make sure DelphiFMX{_module_ext} is built and available at:\n"
+        f"  {_module_file}\n"
         f"Original error: {e}"
     ) from e
 
@@ -59,31 +88,31 @@ class FormForTest(Form):
 class TestLoadProps(unittest.TestCase):
     """Test suite for LoadProps method."""
     
-    # Path to the reference .dfm file in tests directory
-    _TEST_DFM_SOURCE = os.path.join(os.path.dirname(__file__), 'test_form.dfm')
+    # Path to the reference .fmx file in tests directory
+    _TEST_FMX_SOURCE = os.path.join(os.path.dirname(__file__), 'test_form.fmx')
     
     @classmethod
     def setUpClass(cls):
         """Set up test fixtures before all tests."""
         
-        if not os.path.exists(cls._TEST_DFM_SOURCE):
+        if not os.path.exists(cls._TEST_FMX_SOURCE):
             raise FileNotFoundError(
-                f"Test .dfm file not found: {cls._TEST_DFM_SOURCE}\n"
+                f"Test .fmx file not found: {cls._TEST_FMX_SOURCE}\n"
                 "This file must exist for tests to run."
             )
         
         # Create a temporary directory for test files
         cls.test_dir = tempfile.mkdtemp(prefix='p4d_test_')
         
-        # Copy the reference .dfm file to test directory
-        cls.valid_dfm = os.path.join(cls.test_dir, 'test_form.dfm')
-        shutil.copy2(cls._TEST_DFM_SOURCE, cls.valid_dfm)
+        # Copy the reference .fmx file to test directory
+        cls.valid_fmx = os.path.join(cls.test_dir, 'test_form.fmx')
+        shutil.copy2(cls._TEST_FMX_SOURCE, cls.valid_fmx)
         
-        # Create UTF-8 path test directory and copy .dfm file there
+        # Create UTF-8 path test directory and copy .fmx file there
         utf8_dir = os.path.join(cls.test_dir, '测试_тест_🎉')
         os.makedirs(utf8_dir, exist_ok=True)
-        cls.utf8_dfm = os.path.join(utf8_dir, 'form_测试.dfm')
-        shutil.copy2(cls._TEST_DFM_SOURCE, cls.utf8_dfm)
+        cls.utf8_fmx = os.path.join(utf8_dir, 'form_测试.fmx')
+        shutil.copy2(cls._TEST_FMX_SOURCE, cls.utf8_fmx)
     
     @classmethod
     def tearDownClass(cls):
@@ -95,6 +124,7 @@ class TestLoadProps(unittest.TestCase):
     
     def setUp(self):
         """Set up before each test."""
+        # Create a fresh form for each test
         self.form = FormForTest(None)
     
     def tearDown(self):
@@ -105,72 +135,96 @@ class TestLoadProps(unittest.TestCase):
         except:
             pass
     
-    def _copy_dfm_to_path(self, target_path):
-        """Helper to copy the test .dfm file to a specific path."""
+    def _copy_fmx_to_path(self, target_path):
+        """Helper to copy the test .fmx file to a specific path."""
         target_dir = os.path.dirname(target_path)
         if target_dir and not os.path.exists(target_dir):
             os.makedirs(target_dir, exist_ok=True)
-        shutil.copy2(self._TEST_DFM_SOURCE, target_path)
+        shutil.copy2(self._TEST_FMX_SOURCE, target_path)
         return target_path
     
     def _deny_read_access(self, path):
-        """Deny read access to a file or directory using Windows ACLs.
+        """Deny read access to a file or directory using platform-specific methods.
         
         Returns a context manager that restores permissions on exit.
-        Requires win32security (pywin32) module.
+        Cross-platform: Windows uses win32security, Unix uses os.chmod().
         
         Raises:
-            ImportError: If win32security is not available
+            ImportError: If win32security is not available (Windows only)
             Exception: If setting permissions fails
         """
-        try:
-            import win32security
-            import win32api
-            import ntsecuritycon as con
-        except ImportError as e:
-            raise ImportError(
-                f"win32security module (pywin32) is required for permission testing on Windows. "
-                f"Install it with: pip install pywin32. Original error: {e}"
-            ) from e
+        is_windows = platform.system() == 'Windows'
+        is_directory = os.path.isdir(path)
         
-        # Return a context manager for cleanup
-        class PermissionRestorer:
-            def __init__(self, path):
-                self.path = path
-                self.user_sid = win32security.LookupAccountName(None, win32api.GetUserName())[0]
+        if is_windows:
+            try:
+                import win32security
+                import win32api
+                import ntsecuritycon as con
+            except ImportError as e:
+                raise ImportError(
+                    f"win32security module (pywin32) is required for permission testing on Windows. "
+                    f"Install it with: pip install pywin32. Original error: {e}"
+                ) from e
             
-            def __enter__(self):
-                dacl = win32security.ACL()
-                dacl.AddAccessDeniedAce(win32security.ACL_REVISION, con.GENERIC_READ, self.user_sid)
+            class PermissionRestorer:
+                def __init__(self, path):
+                    self.path = path
+                    self.user_sid = win32security.LookupAccountName(None, win32api.GetUserName())[0]
                 
-                # Use SetNamedSecurityInfo with PROTECTED_DACL to disable inheritance
-                win32security.SetNamedSecurityInfo(self.path, win32security.SE_FILE_OBJECT,
-                    win32security.DACL_SECURITY_INFORMATION | win32security.PROTECTED_DACL_SECURITY_INFORMATION,
-                    None, None, dacl, None)
+                def __enter__(self):
+                    dacl = win32security.ACL()
+                    dacl.AddAccessDeniedAce(win32security.ACL_REVISION, con.GENERIC_READ, self.user_sid)
+                    
+                    # Use SetNamedSecurityInfo with PROTECTED_DACL to disable inheritance
+                    win32security.SetNamedSecurityInfo(self.path, win32security.SE_FILE_OBJECT,
+                        win32security.DACL_SECURITY_INFORMATION | win32security.PROTECTED_DACL_SECURITY_INFORMATION,
+                        None, None, dacl, None)
+                    
+                    return self
                 
-                return self
+                def __exit__(self, exc_type, exc_val, exc_tb):
+                    # Restore default permissions
+                    dacl = win32security.ACL()
+                    dacl.AddAccessAllowedAce(win32security.ACL_REVISION, con.GENERIC_ALL, self.user_sid)
+                    win32security.SetNamedSecurityInfo(self.path, win32security.SE_FILE_OBJECT,
+                        win32security.DACL_SECURITY_INFORMATION,
+                        None, None, dacl, None)
+                    return False  # Don't suppress exceptions
             
-            def __exit__(self, exc_type, exc_val, exc_tb):
-                # Restore default permissions
-                dacl = win32security.ACL()
-                dacl.AddAccessAllowedAce(win32security.ACL_REVISION, con.GENERIC_ALL, self.user_sid)
-                win32security.SetNamedSecurityInfo(self.path, win32security.SE_FILE_OBJECT,
-                    win32security.DACL_SECURITY_INFORMATION,
-                    None, None, dacl, None)
-                return False  # Don't suppress exceptions
-        
-        return PermissionRestorer(path)
+            return PermissionRestorer(path)
+        else:
+            import stat
+            class PermissionRestorer:
+                def __init__(self, path, is_directory):
+                    self.path = path
+                    self.is_directory = is_directory
+                    self.original_mode = os.stat(path).st_mode
+                
+                def __enter__(self):
+                    # Remove read and execute permissions (execute needed to access files in directory)
+                    os.chmod(self.path, stat.S_IWRITE)  # Write-only
+                    return self
+                
+                def __exit__(self, exc_type, exc_val, exc_tb):
+                    os.chmod(self.path, self.original_mode)
+                    return False  # Don't suppress exceptions
+            
+            return PermissionRestorer(path, is_directory)
     
     def _lock_file(self, file_path):
         """Lock a file exclusively using Windows file locking.
         
         Returns a context manager that unlocks the file on exit.
-        Requires msvcrt module (Windows only).
+        Windows only - Unix file locking is advisory and not reliable for testing.
         
         Raises:
             ImportError: If msvcrt is not available
             Exception: If locking the file fails
         """
+        if platform.system() != 'Windows':
+            raise NotImplementedError("File locking test only available on Windows - Unix uses advisory locking which is not reliable")
+        
         try:
             import msvcrt
         except ImportError as e:
@@ -184,20 +238,18 @@ class TestLoadProps(unittest.TestCase):
                 self.path = path
                 self.handle = None
                 self.file_size = None
-                self.msvcrt = msvcrt
             
             def __enter__(self):
                 self.handle = open(self.path, 'r+b')
                 self.file_size = os.path.getsize(self.path)
                 # Lock the file exclusively (lock entire file: 0 to file size)
-                self.msvcrt.locking(self.handle.fileno(), self.msvcrt.LK_LOCK, self.file_size)
+                msvcrt.locking(self.handle.fileno(), msvcrt.LK_LOCK, self.file_size)
                 return self
             
             def __exit__(self, exc_type, exc_val, exc_tb):
                 if self.handle:
                     try:
-                        # Unlock the file
-                        self.msvcrt.locking(self.handle.fileno(), self.msvcrt.LK_UNLCK, self.file_size)
+                        msvcrt.locking(self.handle.fileno(), msvcrt.LK_UNLCK, self.file_size)
                     finally:
                         self.handle.close()
                 return False  # Don't suppress exceptions
@@ -205,7 +257,7 @@ class TestLoadProps(unittest.TestCase):
         return FileLocker(file_path)
     
     def _verify_basic_properties_loaded(self, form, msg_prefix=""):
-        """Helper to verify that basic form properties were actually loaded from .dfm file.
+        """Helper to verify that basic form properties were actually loaded from .fmx file.
         
         This ensures LoadProps didn't just return True without doing anything.
         """
@@ -220,14 +272,14 @@ class TestLoadProps(unittest.TestCase):
     
     def test_loadprops_with_string_path(self):
         """Test LoadProps with a regular string path."""
-        result = self.form.LoadProps(self.valid_dfm)
-        self.assertTrue(result, "LoadProps should return True for valid .dfm file")
+        result = self.form.LoadProps(self.valid_fmx)
+        self.assertTrue(result, "LoadProps should return True for valid .fmx file")
         self._verify_basic_properties_loaded(self.form)
 
 
     def test_loadprops_with_pathlib_path(self):
         """Test LoadProps with pathlib.Path object."""
-        path_obj = Path(self.valid_dfm)
+        path_obj = Path(self.valid_fmx)
         result = self.form.LoadProps(path_obj)
         self.assertTrue(result, "LoadProps should return True for valid Path object")
         self._verify_basic_properties_loaded(self.form)
@@ -235,14 +287,14 @@ class TestLoadProps(unittest.TestCase):
 
     def test_loadprops_with_utf8_string_path(self):
         """Test LoadProps with UTF-8 characters in string path."""
-        result = self.form.LoadProps(self.utf8_dfm)
+        result = self.form.LoadProps(self.utf8_fmx)
         self.assertTrue(result, "LoadProps should return True for UTF-8 path")
         self._verify_basic_properties_loaded(self.form)
 
 
     def test_loadprops_with_utf8_pathlib_path(self):
         """Test LoadProps with UTF-8 characters in Path object."""
-        path_obj = Path(self.utf8_dfm)
+        path_obj = Path(self.utf8_fmx)
         result = self.form.LoadProps(path_obj)
         self.assertTrue(result, "LoadProps should return True for UTF-8 Path object")
         self._verify_basic_properties_loaded(self.form)
@@ -250,7 +302,7 @@ class TestLoadProps(unittest.TestCase):
 
     def test_loadprops_with_absolute_path(self):
         """Test LoadProps with absolute path."""
-        abs_path = os.path.abspath(self.valid_dfm)
+        abs_path = os.path.abspath(self.valid_fmx)
         result = self.form.LoadProps(abs_path)
         self.assertTrue(result, "LoadProps should work with absolute path")
         self._verify_basic_properties_loaded(self.form)
@@ -261,7 +313,7 @@ class TestLoadProps(unittest.TestCase):
         old_cwd = os.getcwd()
         try:
             os.chdir(self.test_dir)
-            rel_path = os.path.basename(self.valid_dfm)
+            rel_path = os.path.basename(self.valid_fmx)
             result = self.form.LoadProps(rel_path)
             self.assertTrue(result, "LoadProps should work with relative path")
             self._verify_basic_properties_loaded(self.form)
@@ -272,8 +324,8 @@ class TestLoadProps(unittest.TestCase):
     def test_loadprops_with_path_containing_spaces(self):
         """Test LoadProps with path containing spaces."""
         space_dir = os.path.join(self.test_dir, 'path with spaces')
-        space_file = os.path.join(space_dir, 'test file.dfm')
-        self._copy_dfm_to_path(space_file)
+        space_file = os.path.join(space_dir, 'test file.fmx')
+        self._copy_fmx_to_path(space_file)
         
         result = self.form.LoadProps(space_file)
         self.assertTrue(result, "LoadProps should work with path containing spaces")
@@ -284,7 +336,7 @@ class TestLoadProps(unittest.TestCase):
     
     def test_loadprops_with_nonexistent_file(self):
         """Test LoadProps with non-existent file path."""
-        nonexistent = os.path.join(self.test_dir, 'nonexistent.dfm')
+        nonexistent = os.path.join(self.test_dir, 'nonexistent.fmx')
         
         with self.assertRaises(OSError) as context:
             self.form.LoadProps(nonexistent)
@@ -302,7 +354,7 @@ class TestLoadProps(unittest.TestCase):
         """Test LoadProps with empty string as filename."""
         with self.assertRaises(OSError) as context:
             self.form.LoadProps('')
-        self.assertIn('not found', str(context.exception).lower())
+        self.assertIn('not found', str(context.exception))
 
 
     def test_loadprops_with_integer(self):
@@ -313,9 +365,9 @@ class TestLoadProps(unittest.TestCase):
 
     def test_loadprops_with_wrong_file_content(self):
         """Test LoadProps with file that exists but wrong content."""
-        txt_file = os.path.join(self.test_dir, 'test_wrong_content.dfm')
+        txt_file = os.path.join(self.test_dir, 'test_wrong_content.fmx')
         with open(txt_file, 'w', encoding='utf-8') as f:
-            f.write('not a dfm file')
+            f.write('not a fmx file')
         
         with self.assertRaises(RuntimeError) as context:
             self.form.LoadProps(txt_file)
@@ -324,7 +376,7 @@ class TestLoadProps(unittest.TestCase):
 
     def test_loadprops_with_empty_file(self):
         """Test LoadProps with empty file."""
-        empty_file = os.path.join(self.test_dir, 'empty.dfm')
+        empty_file = os.path.join(self.test_dir, 'empty.fmx')
         with open(empty_file, 'w', encoding='utf-8'):
             pass
         
@@ -332,79 +384,6 @@ class TestLoadProps(unittest.TestCase):
             self.form.LoadProps(empty_file)
         self.assertIn('EReadError', str(context.exception))
     
-
-    def test_loadprops_with_file_no_read_permission(self):
-        """Test LoadProps with file that has no read permissions."""
-        no_read_file = os.path.join(self.test_dir, 'no_read.dfm')
-        self._copy_dfm_to_path(no_read_file)
-        
-        with self._deny_read_access(no_read_file):
-            with self.assertRaises(OSError) as context:
-                self.form.LoadProps(no_read_file)
-            self.assertIn('access is denied', str(context.exception).lower())
-            self.assertIn('EFOpenError', str(context.exception))
-
-
-    def test_loadprops_with_directory_no_read_permission(self):
-        """Test LoadProps with file in directory that has no read permissions."""
-        no_read_dir = os.path.join(self.test_dir, 'no_read_dir')
-        os.makedirs(no_read_dir, exist_ok=True)
-        file_in_no_read_dir = os.path.join(no_read_dir, 'test.dfm')
-        self._copy_dfm_to_path(file_in_no_read_dir)
-        
-        with self._deny_read_access(no_read_dir):
-            with self.assertRaises(OSError) as context:
-                self.form.LoadProps(file_in_no_read_dir)
-            # Not readable directory should lead to file not found error
-            self.assertIn(file_in_no_read_dir, str(context.exception))
-            self.assertIn('not found', str(context.exception))
-
-
-    def test_loadprops_with_locked_file(self):
-        """Test LoadProps with file that is locked by another process."""
-        locked_file = os.path.join(self.test_dir, 'locked.dfm')
-        self._copy_dfm_to_path(locked_file)
-        
-        with self._lock_file(locked_file):
-            with self.assertRaises(OSError) as context:
-                self.form.LoadProps(locked_file)
-            self.assertIn(locked_file, str(context.exception))
-            self.assertIn('EFOpenError', str(context.exception))
-
-
-    def test_loadprops_with_corrupted_binary_file(self):
-        """Test LoadProps with file that looks like binary but is corrupted."""
-        corrupted_file = os.path.join(self.test_dir, 'corrupted.dfm')
-        # Write some binary data that might look like a DFM but is corrupted
-        with open(corrupted_file, 'wb') as f:
-            f.write(b'TPF0')  # Valid signature
-            f.write(b'a' * 100)
-
-        with self.assertRaises(RuntimeError) as context:        
-            self.form.LoadProps(corrupted_file)
-        error_msg = str(context.exception).lower()
-        self.assertTrue(str(context.exception).startswith('EReadError'), f"Expected EReadError, got: {context.exception}")
-
-
-
-    def test_loadprops_with_incomplete_text_file(self):
-        """Test LoadProps with text file that starts correctly but is incomplete."""
-        incomplete_file = os.path.join(self.test_dir, 'incomplete.dfm')
-        # Write partial DFM text content
-        with open(incomplete_file, 'w', encoding='utf-8') as f:
-            f.write('object Form1: TForm1\n')
-            f.write('  Caption = \'Form1\'\n')
-            # Missing closing 'end' and proper structure
-        
-        with self.assertRaises(RuntimeError) as context:
-            self.form.LoadProps(incomplete_file)
-        # Should raise parsing error
-        error_msg = str(context.exception).lower()
-        self.assertTrue(
-            'error' in error_msg or 'parse' in error_msg or 'eparsererror' in error_msg,
-            f"Expected parsing error for incomplete file, got: {context.exception}"
-        )
-
 
     # ========== PathLike Object Edge Cases ==========
 
@@ -416,7 +395,7 @@ class TestLoadProps(unittest.TestCase):
             def __fspath__(self):
                 return self.path
         
-        result = self.form.LoadProps(CustomPathLike(self.valid_dfm))
+        result = self.form.LoadProps(CustomPathLike(self.valid_fmx))
         self.assertTrue(result, "LoadProps should work with custom PathLike")
         self._verify_basic_properties_loaded(self.form)
 
@@ -462,7 +441,7 @@ class TestLoadProps(unittest.TestCase):
                 self.__fspath__ = path
 
         with self.assertRaises(TypeError) as context:
-            self.form.LoadProps(NonCallablePathLike(self.valid_dfm))
+            self.form.LoadProps(NonCallablePathLike(self.valid_fmx))
         self.assertIn('Expected argument type(s): str, bytes or os.PathLike', str(context.exception))
 
 
@@ -474,14 +453,14 @@ class TestLoadProps(unittest.TestCase):
             def __fspath__(self):
                 return self.path
         
-        result = self.form.LoadProps(UTF8PathLike(self.utf8_dfm))
+        result = self.form.LoadProps(UTF8PathLike(self.utf8_fmx))
         self.assertTrue(result, "LoadProps should work with UTF-8 PathLike")
         self._verify_basic_properties_loaded(self.form)
 
 
     def test_loadprops_with_bytes_path(self):
         """Test LoadProps with bytes object as path."""
-        bytes_path = self.valid_dfm.encode('utf-8')
+        bytes_path = self.valid_fmx.encode('utf-8')
         result = self.form.LoadProps(bytes_path)
         self.assertTrue(result, "LoadProps should work with bytes path")
         self._verify_basic_properties_loaded(self.form)
@@ -489,7 +468,7 @@ class TestLoadProps(unittest.TestCase):
 
     def test_loadprops_with_bytes_path_utf8(self):
         """Test LoadProps with UTF-8 bytes path."""
-        bytes_path = self.utf8_dfm.encode('utf-8')
+        bytes_path = self.utf8_fmx.encode('utf-8')
         result = self.form.LoadProps(bytes_path)
         self.assertTrue(result, "LoadProps should work with UTF-8 bytes path")
         self._verify_basic_properties_loaded(self.form)
@@ -503,7 +482,7 @@ class TestLoadProps(unittest.TestCase):
             def __fspath__(self):
                 return self.path.encode('utf-8')
         
-        bytes_pathlike = BytesPathLike(self.valid_dfm)
+        bytes_pathlike = BytesPathLike(self.valid_fmx)
         result = self.form.LoadProps(bytes_pathlike)
         self.assertTrue(result, "LoadProps should work with PathLike returning bytes")
         self._verify_basic_properties_loaded(self.form)
@@ -518,7 +497,7 @@ class TestLoadProps(unittest.TestCase):
             def __fspath__(self):
                 return self.path.encode('utf-8')
         
-        utf8_bytes_pathlike = UTF8BytesPathLike(self.utf8_dfm)
+        utf8_bytes_pathlike = UTF8BytesPathLike(self.utf8_fmx)
         result = self.form.LoadProps(utf8_bytes_pathlike)
         self.assertTrue(result, "LoadProps should work with PathLike returning UTF-8 bytes")
         self._verify_basic_properties_loaded(self.form)
@@ -542,10 +521,64 @@ class TestLoadProps(unittest.TestCase):
         self.form.ClientWidth = 100
         self.form.ClientHeight = 100
         
-        result = self.form.LoadProps(self.valid_dfm)
+        result = self.form.LoadProps(self.valid_fmx)
         self.assertTrue(result)
         self._verify_basic_properties_loaded(self.form)
     
+    def test_loadprops_with_file_no_read_permission(self):
+        """Test LoadProps with file that has no read permissions."""
+        no_read_file = os.path.join(self.test_dir, 'no_read.fmx')
+        self._copy_fmx_to_path(no_read_file)
+        
+        with self._deny_read_access(no_read_file):
+            with self.assertRaises(OSError) as context:
+                self.form.LoadProps(no_read_file)
+            self.assertIn('access is denied', str(context.exception).lower())
+            self.assertIn('EFOpenError', str(context.exception))
+
+    def test_loadprops_with_directory_no_read_permission(self):
+        """Test LoadProps with file in directory that has no read permissions."""
+        no_read_dir = os.path.join(self.test_dir, 'no_read_dir')
+        os.makedirs(no_read_dir, exist_ok=True)
+        file_in_no_read_dir = os.path.join(no_read_dir, 'test.fmx')
+        self._copy_fmx_to_path(file_in_no_read_dir)
+        
+        with self._deny_read_access(no_read_dir):
+            with self.assertRaises(OSError) as context:
+                self.form.LoadProps(file_in_no_read_dir)
+            # Not readable directory should lead to file not found or permission error
+            self.assertIn(file_in_no_read_dir, str(context.exception))
+            self.assertIn('not found', str(context.exception))
+
+    def test_loadprops_with_locked_file(self):
+        """Test LoadProps with file that is locked by another process.
+        
+        Windows only - Unix file locking is advisory and not reliable for testing.
+        """
+        if platform.system() != 'Windows':
+            self.skipTest("File locking test only available on Windows - Unix uses advisory locking")
+        
+        locked_file = os.path.join(self.test_dir, 'locked.fmx')
+        self._copy_fmx_to_path(locked_file)
+        
+        with self._lock_file(locked_file):
+            with self.assertRaises(OSError) as context:
+                self.form.LoadProps(locked_file)
+            self.assertIn(locked_file, str(context.exception))
+            self.assertIn('EFOpenError', str(context.exception))
+
+    def test_loadprops_with_corrupted_binary_file(self):
+        """Test LoadProps with file that looks like binary but is corrupted."""
+        corrupted_file = os.path.join(self.test_dir, 'corrupted.fmx')
+        # Write some binary data that might look like a FMX but is corrupted
+        with open(corrupted_file, 'wb') as f:
+            f.write(b'TPF0')  # Valid signature
+            f.write(b'a' * 100)
+
+        with self.assertRaises(RuntimeError) as context:        
+            self.form.LoadProps(corrupted_file)
+        self.assertTrue(str(context.exception).startswith('EReadError'), f"Expected EReadError, got: {context.exception}")
+
 
 def run_tests():
     """Run all tests."""

--- a/Modules/DelphiFMX/tests/test_form.fmx
+++ b/Modules/DelphiFMX/tests/test_form.fmx
@@ -1,0 +1,12 @@
+object Form1: TForm1
+  Left = 0
+  Top = 0
+  Caption = 'Form1'
+  ClientHeight = 441
+  ClientWidth = 624
+  FormFactor.Width = 320
+  FormFactor.Height = 480
+  FormFactor.Devices = [Desktop]
+  DesignerMasterStyle = 0
+end
+

--- a/Modules/DelphiFMX/tests/test_form.fmx
+++ b/Modules/DelphiFMX/tests/test_form.fmx
@@ -8,5 +8,21 @@ object Form1: TForm1
   FormFactor.Height = 480
   FormFactor.Devices = [Desktop]
   DesignerMasterStyle = 0
+  object Edit1: TEdit
+    Left = 80
+    Top = 256
+    Width = 121
+    Height = 23
+    TabOrder = 3
+    Text = 'Edit1'
+  end
+  object Button1: TButton
+    Left = 184
+    Top = 392
+    Width = 75
+    Height = 25
+    Text = 'Button1'
+    TabOrder = 4
+  end
 end
 

--- a/Modules/DelphiVCL/tests/TestLoadProps.py
+++ b/Modules/DelphiVCL/tests/TestLoadProps.py
@@ -1,0 +1,401 @@
+"""
+Comprehensive tests for LoadProps method in DelphiVCL module.
+
+Tests cover:
+- Valid inputs (str, PathLike objects)
+- Invalid inputs (wrong types, non-existent files)
+- UTF-8 path handling
+- Edge cases and error conditions
+- PathLike objects with unusual behavior
+"""
+
+import unittest
+import os
+import sys
+import tempfile
+import shutil
+import platform
+from pathlib import Path
+
+# Ensure DelphiVCL .pyd can be found
+# This is a minimal solution for test environment - in production, the module
+# should be properly installed or PYTHONPATH should be set
+_test_dir = os.path.dirname(os.path.abspath(__file__))
+_module_dir = os.path.dirname(_test_dir)
+
+# Detect platform architecture
+_is_64bit = sys.maxsize > 2**32
+_platform_dir = 'Win64' if _is_64bit else 'Win32'
+_pyd_dir = os.path.join(_module_dir, 'pyd', 'Release', _platform_dir)
+
+# Add pyd directory to sys.path if it exists and not already there
+if os.path.exists(_pyd_dir) and _pyd_dir not in sys.path:
+    sys.path.insert(0, _pyd_dir)
+
+# Import DelphiVCL module - fail loudly if not available
+try:
+    from DelphiVCL import Form, Application
+except ImportError as e:
+    raise ImportError(
+        f"Failed to import DelphiVCL module. "
+        f"Tried to load from: {_pyd_dir}\n"
+        f"Make sure DelphiVCL.pyd is built and available. "
+        f"Original error: {e}"
+    ) from e
+
+
+class TestForm(Form):
+    """Test form class - allows for adding subcomponents at LoadProps."""
+    pass
+
+
+class TestLoadProps(unittest.TestCase):
+    """Test suite for LoadProps method."""
+    
+    # Path to the reference .dfm file in tests directory
+    _TEST_DFM_SOURCE = os.path.join(os.path.dirname(__file__), 'test_form.dfm')
+    
+    @classmethod
+    def setUpClass(cls):
+        """Set up test fixtures before all tests."""
+        
+        if not os.path.exists(cls._TEST_DFM_SOURCE):
+            raise FileNotFoundError(
+                f"Test .dfm file not found: {cls._TEST_DFM_SOURCE}\n"
+                "This file must exist for tests to run."
+            )
+        
+        # Create a temporary directory for test files
+        cls.test_dir = tempfile.mkdtemp(prefix='p4d_test_')
+        
+        # Copy the reference .dfm file to test directory
+        cls.valid_dfm = os.path.join(cls.test_dir, 'test_form.dfm')
+        shutil.copy2(cls._TEST_DFM_SOURCE, cls.valid_dfm)
+        
+        # Create UTF-8 path test directory and copy .dfm file there
+        utf8_dir = os.path.join(cls.test_dir, '测试_тест_🎉')
+        os.makedirs(utf8_dir, exist_ok=True)
+        cls.utf8_dfm = os.path.join(utf8_dir, 'form_测试.dfm')
+        shutil.copy2(cls._TEST_DFM_SOURCE, cls.utf8_dfm)
+    
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up test fixtures after all tests."""
+        try:
+            shutil.rmtree(cls.test_dir)
+        except:
+            pass
+    
+    def setUp(self):
+        """Set up before each test."""
+        # Create a fresh form for each test
+        self.form = TestForm(None)
+    
+    def tearDown(self):
+        """Clean up after each test."""
+        try:
+            if hasattr(self, 'form') and self.form:
+                self.form.Release()
+        except:
+            pass
+    
+    def _copy_dfm_to_path(self, target_path):
+        """Helper to copy the test .dfm file to a specific path."""
+        target_dir = os.path.dirname(target_path)
+        if target_dir and not os.path.exists(target_dir):
+            os.makedirs(target_dir, exist_ok=True)
+        shutil.copy2(self._TEST_DFM_SOURCE, target_path)
+        return target_path
+    
+    def _verify_basic_properties_loaded(self, form, msg_prefix=""):
+        """Helper to verify that basic form properties were actually loaded from .dfm file.
+        
+        This ensures LoadProps didn't just return True without doing anything.
+        """
+        self.assertEqual(form.Caption, 'Form1', 
+                        f"{msg_prefix}Caption should be 'Form1' after LoadProps")
+        self.assertEqual(form.ClientWidth, 624, 
+                        f"{msg_prefix}ClientWidth should be 624 after LoadProps")
+        self.assertEqual(form.ClientHeight, 441, 
+                        f"{msg_prefix}ClientHeight should be 441 after LoadProps")
+    
+    # ========== Valid Input Tests ==========
+    
+    def test_loadprops_with_string_path(self):
+        """Test LoadProps with a regular string path."""
+        result = self.form.LoadProps(self.valid_dfm)
+        self.assertTrue(result, "LoadProps should return True for valid .dfm file")
+        self._verify_basic_properties_loaded(self.form)
+    
+    def test_loadprops_with_pathlib_path(self):
+        """Test LoadProps with pathlib.Path object."""
+        path_obj = Path(self.valid_dfm)
+        result = self.form.LoadProps(path_obj)
+        self.assertTrue(result, "LoadProps should return True for valid Path object")
+        self._verify_basic_properties_loaded(self.form)
+    
+    def test_loadprops_with_utf8_string_path(self):
+        """Test LoadProps with UTF-8 characters in string path."""
+        result = self.form.LoadProps(self.utf8_dfm)
+        self.assertTrue(result, "LoadProps should return True for UTF-8 path")
+        self._verify_basic_properties_loaded(self.form)
+    
+    def test_loadprops_with_utf8_pathlib_path(self):
+        """Test LoadProps with UTF-8 characters in Path object."""
+        path_obj = Path(self.utf8_dfm)
+        result = self.form.LoadProps(path_obj)
+        self.assertTrue(result, "LoadProps should return True for UTF-8 Path object")
+        self._verify_basic_properties_loaded(self.form)
+    
+    def test_loadprops_with_absolute_path(self):
+        """Test LoadProps with absolute path."""
+        abs_path = os.path.abspath(self.valid_dfm)
+        result = self.form.LoadProps(abs_path)
+        self.assertTrue(result, "LoadProps should work with absolute path")
+        self._verify_basic_properties_loaded(self.form)
+    
+    def test_loadprops_with_relative_path(self):
+        """Test LoadProps with relative path."""
+        # Change to test directory and use relative path
+
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(self.test_dir)
+            rel_path = os.path.basename(self.valid_dfm)
+            result = self.form.LoadProps(rel_path)
+            self.assertTrue(result, "LoadProps should work with relative path")
+            self._verify_basic_properties_loaded(self.form)
+        finally:
+            os.chdir(old_cwd)
+    
+    def test_loadprops_with_path_containing_spaces(self):
+        """Test LoadProps with path containing spaces."""
+        space_dir = os.path.join(self.test_dir, 'path with spaces')
+        space_file = os.path.join(space_dir, 'test file.dfm')
+        self._copy_dfm_to_path(space_file)
+        
+        result = self.form.LoadProps(space_file)
+        self.assertTrue(result, "LoadProps should work with path containing spaces")
+        self._verify_basic_properties_loaded(self.form)
+    
+
+
+    # ========== Invalid Input Tests ==========
+    
+    def test_loadprops_with_nonexistent_file(self):
+        """Test LoadProps with non-existent file path."""
+        nonexistent = os.path.join(self.test_dir, 'nonexistent.dfm')
+        
+        with self.assertRaises(OSError) as context:
+            self.form.LoadProps(nonexistent)
+        self.assertIn('not found', str(context.exception).lower())
+    
+    def test_loadprops_with_none(self):
+        """Test LoadProps with None (should raise TypeError)."""
+        with self.assertRaises(TypeError):
+            self.form.LoadProps(None)
+    
+    def test_loadprops_with_empty_string(self):
+        """Test LoadProps with empty string."""
+        with self.assertRaises(OSError) as context:
+            self.form.LoadProps('')
+        self.assertIn('not found', str(context.exception).lower())
+    
+    def test_loadprops_with_integer(self):
+        """Test LoadProps with integer (wrong type)."""
+        with self.assertRaises(TypeError):
+            self.form.LoadProps(123)
+    
+    def test_loadprops_with_wrong_file_content(self):
+        """Test LoadProps with file that exists but wrong extension."""
+        # Create a text file with wrong extension
+        txt_file = os.path.join(self.test_dir, 'test_wrong_content.dfm')
+        with open(txt_file, 'w', encoding='utf-8') as f:
+            f.write('not a dfm file')
+        
+        with self.assertRaises(RuntimeError) as context:
+            self.form.LoadProps(txt_file)
+        self.assertIn('EParserError', str(context.exception))
+    
+    # ========== PathLike Object Edge Cases ==========
+    
+    def test_loadprops_with_custom_pathlike(self):
+        """Test LoadProps with custom PathLike object."""
+        class CustomPathLike:
+            def __init__(self, path):
+                self.path = path
+            def __fspath__(self):
+                return self.path
+        
+        result = self.form.LoadProps(CustomPathLike(self.valid_dfm))
+        self.assertTrue(result, "LoadProps should work with custom PathLike")
+        self._verify_basic_properties_loaded(self.form)
+
+    
+    def test_loadprops_with_pathlike_raising_exception(self):
+        """Test LoadProps with PathLike that raises exception in __fspath__."""
+        class ExceptionPathLike:
+            def __fspath__(self):
+                raise ValueError("Custom exception from __fspath__")
+        
+        # The exception from __fspath__ should propagate
+        with self.assertRaises(ValueError) as context:
+            self.form.LoadProps(ExceptionPathLike())
+        self.assertIn("Custom exception from __fspath__", str(context.exception))
+    
+    def test_loadprops_with_pathlike_returning_none(self):
+        """Test LoadProps with PathLike that returns None from __fspath__."""
+        class NonePathLike:
+            def __fspath__(self):
+                return None
+        
+        with self.assertRaises(TypeError) as context:
+            self.form.LoadProps(NonePathLike())
+        self.assertIn('Python function `__fspath__` should return value of following type(s): str or bytes. Instead type `NoneType` was returned.', str(context.exception))
+    
+    def test_loadprops_with_pathlike_returning_integer(self):
+        """Test LoadProps with PathLike that returns integer from __fspath__."""
+        class IntPathLike:
+            def __fspath__(self):
+                return 42
+        
+        with self.assertRaises(TypeError) as context:
+            self.form.LoadProps(IntPathLike())
+        self.assertIn('Python function `__fspath__` should return value of following type(s): str or bytes. Instead type `int` was returned.', str(context.exception))
+    
+    def test_loadprops_with_pathlike_utf8(self):
+        """Test LoadProps with custom PathLike returning UTF-8 path."""
+        class UTF8PathLike:
+            def __init__(self, path):
+                self.path = path
+            def __fspath__(self):
+                return self.path
+        
+        result = self.form.LoadProps(UTF8PathLike(self.utf8_dfm))
+        self.assertTrue(result, "LoadProps should work with UTF-8 PathLike")
+        self._verify_basic_properties_loaded(self.form)
+    
+    def test_loadprops_with_bytes_path(self):
+        """Test LoadProps with bytes object as path."""
+        bytes_path = self.valid_dfm.encode('utf-8')
+        result = self.form.LoadProps(bytes_path)
+        self.assertTrue(result, "LoadProps should work with bytes path")
+        self._verify_basic_properties_loaded(self.form)
+    
+    def test_loadprops_with_bytes_path_utf8(self):
+        """Test LoadProps with UTF-8 bytes path."""
+        bytes_path = self.utf8_dfm.encode('utf-8')
+        result = self.form.LoadProps(bytes_path)
+        self.assertTrue(result, "LoadProps should work with UTF-8 bytes path")
+        self._verify_basic_properties_loaded(self.form)
+    
+    def test_loadprops_with_pathlike_returning_bytes(self):
+        """Test LoadProps with PathLike that returns bytes from __fspath__."""
+        class BytesPathLike:
+            def __init__(self, path):
+                self.path = path
+            def __fspath__(self):
+                return self.path.encode('utf-8')
+        
+        bytes_pathlike = BytesPathLike(self.valid_dfm)
+        result = self.form.LoadProps(bytes_pathlike)
+        self.assertTrue(result, "LoadProps should work with PathLike returning bytes")
+        self._verify_basic_properties_loaded(self.form)
+    
+    def test_loadprops_with_pathlike_returning_bytes_utf8(self):
+        """Test LoadProps with PathLike returning UTF-8 bytes."""
+        class UTF8BytesPathLike:
+            """PathLike that returns UTF-8 bytes."""
+            def __init__(self, path):
+                self.path = path
+            def __fspath__(self):
+                return self.path.encode('utf-8')
+        
+        utf8_bytes_pathlike = UTF8BytesPathLike(self.utf8_dfm)
+        result = self.form.LoadProps(utf8_bytes_pathlike)
+        self.assertTrue(result, "LoadProps should work with PathLike returning UTF-8 bytes")
+        self._verify_basic_properties_loaded(self.form)
+    
+    def test_loadprops_with_pathlike_returning_bytes_invalid_encoding(self):
+        """Test LoadProps with PathLike returning bytes with invalid encoding."""
+        class InvalidBytesPathLike:
+            def __fspath__(self):
+                # Return bytes that are not valid UTF-8
+                return b'\xff\xfe\x00\x01'
+        
+        with self.assertRaises(UnicodeDecodeError) as context:
+            self.form.LoadProps(InvalidBytesPathLike())
+        
+    
+    # ========== Edge Cases ==========
+    
+    def test_loadprops_with_very_long_path(self):
+        """Test LoadProps with very long path."""
+        # Create a path with many nested directories
+        long_path = self.test_dir
+        for i in range(10):
+            long_path = os.path.join(long_path, f'dir_{i}' * 20)
+        os.makedirs(long_path, exist_ok=True)
+        
+        long_file = os.path.join(long_path, 'test.dfm')
+        self._copy_dfm_to_path(long_file)
+        
+        # Should work if path length is within system limits
+        try:
+            result = self.form.LoadProps(long_file)
+            self.assertTrue(result, "LoadProps should work with long path if within system limits")
+            self._verify_basic_properties_loaded(self.form)
+        except (OSError, RuntimeError) as e:
+            # Very long paths might fail on some systems - that's acceptable
+            error_msg = str(e).lower()
+            if any(term in error_msg for term in ['too long', 'path', 'filename']):
+                # Expected failure for path length limits
+                pass
+            else:
+                # Unexpected error - re-raise
+                raise
+    
+    def test_loadprops_with_unicode_normalization(self):
+        """Test LoadProps handles Unicode normalization correctly."""
+        # Test with different Unicode representations
+        # Create directory with combining characters
+        if sys.platform == 'win32':
+            # Windows may normalize Unicode differently
+            # Test with é (U+00E9) vs e + U+0301 (combining acute)
+            normalized_dir = os.path.join(self.test_dir, 'café')
+            normalized_file = os.path.join(normalized_dir, 'form.dfm')
+            self._copy_dfm_to_path(normalized_file)
+            
+            result = self.form.LoadProps(normalized_file)
+            self.assertTrue(result, "LoadProps should handle Unicode normalization")
+            self._verify_basic_properties_loaded(self.form)
+    
+    def test_loadprops_overwrites_existing_properties(self):
+        """Test that LoadProps overwrites existing form properties."""
+        self.form.Caption = 'Initial Caption'
+        self.form.ClientWidth = 100
+        self.form.ClientHeight = 100
+        
+        result = self.form.LoadProps(self.valid_dfm)
+        self.assertTrue(result)
+        self._verify_basic_properties_loaded(self.form)
+    
+
+def run_tests():
+    """Run all tests."""
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    
+    # Add all test classes
+    suite.addTests(loader.loadTestsFromTestCase(TestLoadProps))
+    
+    # Run tests with default unittest runner
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+    
+    # Return exit code
+    return 0 if result.wasSuccessful() else 1
+
+
+if __name__ == '__main__':
+    sys.exit(run_tests())

--- a/Modules/DelphiVCL/tests/test_form.dfm
+++ b/Modules/DelphiVCL/tests/test_form.dfm
@@ -1,0 +1,56 @@
+object Form1: TForm1
+  Left = 0
+  Top = 0
+  Caption = 'Form1'
+  ClientHeight = 441
+  ClientWidth = 624
+  Color = clBtnFace
+  Font.Charset = DEFAULT_CHARSET
+  Font.Color = clWindowText
+  Font.Height = -12
+  Font.Name = 'Segoe UI'
+  Font.Style = []
+  TextHeight = 15
+  object SpinEdit1: TSpinEdit
+    Left = 216
+    Top = 328
+    Width = 121
+    Height = 24
+    MaxValue = 0
+    MinValue = 0
+    TabOrder = 0
+    Value = 0
+  end
+  object ActivityIndicator1: TActivityIndicator
+    Left = 496
+    Top = 328
+  end
+  object LabeledEdit1: TLabeledEdit
+    Left = 80
+    Top = 208
+    Width = 121
+    Height = 23
+    EditLabel.Width = 67
+    EditLabel.Height = 15
+    EditLabel.Caption = 'LabeledEdit1'
+    TabOrder = 2
+    Text = ''
+  end
+  object Edit1: TEdit
+    Left = 80
+    Top = 256
+    Width = 121
+    Height = 23
+    TabOrder = 3
+    Text = 'Edit1'
+  end
+  object Button1: TButton
+    Left = 184
+    Top = 392
+    Width = 75
+    Height = 25
+    Caption = 'Button1'
+    TabOrder = 4
+  end
+end
+

--- a/Source/WrapDelphiClasses.pas
+++ b/Source/WrapDelphiClasses.pas
@@ -1096,8 +1096,9 @@ var
   LInput: TFileStream;
   LOutput: TMemoryStream;
 begin
-  if AResFile.IsEmpty or not FileExists(AResFile) then
-    Exit(false);
+  if AResFile.IsEmpty or not FileExists(AResFile) then begin
+    raise EPyOSError.CreateFmt('File `%s` not found.', [AResFile]);
+  end;
 
   LInput := TFileStream.Create(AResFile, fmOpenRead);
   try

--- a/Source/WrapDelphiClasses.pas
+++ b/Source/WrapDelphiClasses.pas
@@ -1096,9 +1096,9 @@ var
   LInput: TFileStream;
   LOutput: TMemoryStream;
 begin
-  if AResFile.IsEmpty or not FileExists(AResFile) then begin
+//  if AResFile.IsEmpty or not FileExists(AResFile) then begin
+  if not FileExists(AResFile) then
     raise EPyOSError.CreateFmt('File `%s` not found.', [AResFile]);
-  end;
 
   LInput := TFileStream.Create(AResFile, fmOpenRead);
   try

--- a/Source/WrapDelphiClasses.pas
+++ b/Source/WrapDelphiClasses.pas
@@ -1096,7 +1096,6 @@ var
   LInput: TFileStream;
   LOutput: TMemoryStream;
 begin
-//  if AResFile.IsEmpty or not FileExists(AResFile) then begin
   if not FileExists(AResFile) then
     raise EPyOSError.CreateFmt('File `%s` not found.', [AResFile]);
 

--- a/Source/vcl/WrapVclForms.pas
+++ b/Source/vcl/WrapVclForms.pas
@@ -549,30 +549,23 @@ begin
 end;
 
 function TPyDelphiCustomForm.LoadProps_Wrapper(args: PPyObject): PPyObject;
-
-  function FindResource(): string;
-  var
-    LStr: PAnsiChar;
-  begin
-    with GetPythonEngine() do begin
-      if PyArg_ParseTuple(args, 's:LoadProps', @LStr) <> 0 then begin
-        Result := string(LStr);
-      end else
-        Result := String.Empty;
-    end;
-  end;
-
 begin
   Adjust(@Self);
   try
-    if InternalReadComponent(FindResource(), DelphiObject) then
-      Exit(GetPythonEngine().ReturnTrue)
-    else
-      Exit(GetPythonEngine().ReturnFalse);
+    with GetPythonEngine() do begin
+      var path: PPyObject;
+      if PyArg_ParseTuple(args, 'O:LoadProps', @path) = 0 then
+        Exit(nil);   // Python exception is already set.
+      if InternalReadComponent(PyFSPathObjectAsString(path), DelphiObject) then
+        Exit(ReturnTrue)
+      else
+        Exit(ReturnFalse);
+    end;
   except
     on E: Exception do
-      with GetPythonEngine() do
-        PyErr_SetString(PyExc_RuntimeError^, PAnsiChar(EncodeString(E.Message)));
+      with GetPythonEngine() do begin
+        SetPyErrFromException(E);
+      end;
   end;
   Result := nil;
 end;

--- a/Source/vcl/WrapVclForms.pas
+++ b/Source/vcl/WrapVclForms.pas
@@ -549,11 +549,12 @@ begin
 end;
 
 function TPyDelphiCustomForm.LoadProps_Wrapper(args: PPyObject): PPyObject;
+var
+  path: PPyObject;
 begin
   Adjust(@Self);
   try
     with GetPythonEngine() do begin
-      var path: PPyObject;
       if PyArg_ParseTuple(args, 'O:LoadProps', @path) = 0 then
         Exit(nil);   // Python exception is already set.
       if InternalReadComponent(PyFSPathObjectAsString(path), DelphiObject) then


### PR DESCRIPTION
Hello, 
i added support for unicode filenames for Form.LoadProps() methods. 

Initially I thought it would be short and simple, but correct work with unicode and filesystem has its quirks. 
Also be conforming to python PEPs added some work. 
Since there are a lot of possible exceptions and errors, i also extended support for unicode exceptions somewhat. The additional features are: 
1. LoadProps now support unicode string as filepath 
2. LoadProps now support bytes as filepath 
3. LoadProps now support os.PathLike objects as filepath 
4. Generic handler for Delphi exceptions -> Python exceptions has been added (as a mirror to RaiseError; which handles python exception -> delphi exception) 
5.  There was no test for python vcl/fmx libraries, so i added one file per library - though i added only tests for new unicode functionality. I know its not completely conceptual, but i didnt want to add to this PR too much new stuff and since there wasnt nothing yet... The test is runnable either standalone without any additional dependencies, or via pytest (for more nice and detailed output) 


Note: I want to apologize beforehand - im not delphi pro, last time i worked more with delphi was 25yrs ago, so i want to apologize for the stupid stuff i may have made. However sometime ago i accidentaly found delphifmx and delphivcl python libraries and i was so amazed(i liked vcl a lot then), so i started to use it for my hobby project...