### PR TITLE
Solved ios compile error

### DIFF
--- a/Source/PythonEngine.pas
+++ b/Source/PythonEngine.pas
@@ -1991,8 +1991,8 @@ const
   DEFAULT_DATETIME_CONVERSION_MODE = dcmToTuple;
   DEFAULT_FLAGS =
     {$IFDEF IOS}
-    [pfIsolated, pfNoUserSiteDirectory, pfIgnoreEnvironment,
-    pfDontWriteBytecodeFlag]
+    [pfIsolated, pfNoUserSiteDirectory, pfIgnoreEnvironment]//,
+    //pfDontWriteBytecodeFlag]
     {$ELSE}
     []
     {$ENDIF IOS};


### PR DESCRIPTION
with this unused const couldnt compile ios in delphi 13. removed const and successfully compiled